### PR TITLE
Initial tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max_line_length = 140

--- a/stretch_core/package.xml
+++ b/stretch_core/package.xml
@@ -49,7 +49,9 @@
   <exec_depend>teleop_twist_keyboard</exec_depend>
   <!-- stretch_driver_test has not been ported yet
        test_depend>rostest</test_depend-->
-
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/stretch_core/setup.py
+++ b/stretch_core/setup.py
@@ -19,6 +19,7 @@ setup(
     author='Hello Robot Inc.',
     author_email='support@hello-robot.com',
     description='The stretch_core package',
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'stretch_driver = stretch_core.stretch_driver:main',

--- a/stretch_core/stretch_core/rwlock.py
+++ b/stretch_core/stretch_core/rwlock.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python3
-"""rwlock.py
+"""
+Non-reentrant write-preferring rwlock.
+
 This write-preferring implementation of the readwrite lock
 was made available via the Creative Commons license at:
 https://stackoverflow.com/a/22109979
@@ -7,8 +9,10 @@ https://stackoverflow.com/a/22109979
 
 import threading
 
+
 class RWLock:
-    """ Non-reentrant write-preferring rwlock. """
+    """Non-reentrant write-preferring rwlock."""
+
     DEBUG = 0
 
     def __init__(self):
@@ -31,9 +35,11 @@ class RWLock:
         class _ReadAccess:
             def __init__(self, rwlock):
                 self.rwlock = rwlock
+
             def __enter__(self):
                 self.rwlock.acquire_read()
                 return self.rwlock
+
             def __exit__(self, type, value, tb):
                 self.rwlock.release_read()
         # support for the with statement
@@ -42,9 +48,11 @@ class RWLock:
         class _WriteAccess:
             def __init__(self, rwlock):
                 self.rwlock = rwlock
+
             def __enter__(self):
                 self.rwlock.acquire_write()
                 return self.rwlock
+
             def __exit__(self, type, value, tb):
                 self.rwlock.release_write()
         # support for the with statement

--- a/stretch_core/test/test_flake8.py
+++ b/stretch_core/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=['--config', '../.flake8', '--exclude', 'tests', 'nodes'])
+    assert rc == 0, \
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)

--- a/stretch_core/test/test_pep257.py
+++ b/stretch_core/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/stretch_description/meshes/update_meshes.py
+++ b/stretch_description/meshes/update_meshes.py
@@ -2,7 +2,8 @@
 import os
 import stretch_body.hello_utils as hu
 batch_name = hu.read_fleet_yaml('stretch_re1_factory_params.yaml')['robot']['batch_name'].lower()
-cmd='cp ~/catkin_ws/src/stretch_ros/stretch_description/meshes/'+batch_name+'/*.STL ~/catkin_ws/src/stretch_ros/stretch_description/meshes'
-print("Copying in mesh files from batch:"+batch_name)
+cmd = 'cp ~/catkin_ws/src/stretch_ros/stretch_description/meshes/' + batch_name + '/*.STL ' \
+      '~/catkin_ws/src/stretch_ros/stretch_description/meshes'
+print("Copying in mesh files from batch:" + batch_name)
 print(cmd)
 os.system(cmd)

--- a/stretch_description/package.xml
+++ b/stretch_description/package.xml
@@ -29,6 +29,9 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/stretch_description/test/test_flake8.py
+++ b/stretch_description/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=['--config', '../.flake8'])
+    assert rc == 0, \
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)

--- a/stretch_description/test/test_pep257.py
+++ b/stretch_description/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
 * Adds copyright headers to all Python files in `stretch_core` (and runs the copyright header test)
     * `strech_description` is licensed with `CC BY-NC-SA 4.0 (Attribution-NonCommercial-ShareAlike 4.0 International)` so I wasn't sure what header to put. 
 * Adds both standard linters (pep257/flake8) to `stretch_core` and `stretch_description`.
      * Currently the tests pass for the ported files, namely 
          * `stretch_core/launch/stretch_driver.launch.py`
          * `stretch_core/stretch_core/*.py `
          * All of `stretch_description/`

As the additional code gets ported, it will be linted as we go. 