### PR TITLE
Stretch Simple Controller Manager Hack

### DIFF
--- a/stretch_moveit_config/config/trajectory_execution.yaml
+++ b/stretch_moveit_config/config/trajectory_execution.yaml
@@ -2,7 +2,7 @@
 /**:
     ros__parameters:
         moveit_manage_controllers: true
-        moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
+        moveit_controller_manager: stretch_simple_controller_manager/MoveItSimpleControllerManager
         trajectory_execution:
             # When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution
             allowed_execution_duration_scaling: 1.2
@@ -10,7 +10,7 @@
             allowed_goal_duration_margin: 0.5
             # Allowed joint-value tolerance for validation that trajectory's first point matches current robot state
             allowed_start_tolerance: 0.01
-        moveit_simple_controller_manager:
+        stretch_simple_controller_manager:
             controller_names:
               - stretch_controller
 

--- a/stretch_moveit_config/package.xml
+++ b/stretch_moveit_config/package.xml
@@ -26,7 +26,7 @@
   <run_depend>moveit_ros_perception</run_depend>
   <!-- TODO(JafarAbdi): uncomment once MSA is ported -->
   <!-- run_depend>moveit_setup_assistant</run_depend -->
-  <run_depend>moveit_simple_controller_manager</run_depend>
+  <run_depend>stretch_simple_controller_manager</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>stretch_description</run_depend>
   <run_depend>tf2_ros</run_depend>

--- a/stretch_simple_controller_manager/CHANGELOG.rst
+++ b/stretch_simple_controller_manager/CHANGELOG.rst
@@ -1,0 +1,226 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package moveit_simple_controller_manager
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+2.3.0 (2021-10-08)
+------------------
+* Fix cmake warnings (`#690 <https://github.com/ros-planning/moveit2/issues/690>`_)
+  * Fix -Wformat-security
+  * Fix -Wunused-variable
+  * Fix -Wunused-lambda-capture
+  * Fix -Wdeprecated-declarations
+  * Fix clang-tidy, readability-identifier-naming in moveit_kinematics
+* follow_joint_trajectory_controller_handle: publish new multi_dof_trajectory field (`#492 <https://github.com/ros-planning/moveit2/issues/492>`_)
+* Contributors: Henning Kayser, Jafar Abdi, David V. Lu
+
+2.2.1 (2021-07-12)
+------------------
+
+2.2.0 (2021-06-30)
+------------------
+* Enable Rolling and Galactic CI (`#494 <https://github.com/ros-planning/moveit2/issues/494>`_)
+* [sync] MoveIt's master branch up-to https://github.com/ros-planning/moveit/commit/0d0a6a171b3fbea97a0c4f284e13433ba66a4ea4
+* Contributors: Henning Kayser, JafarAbdi, Tyler Weaver, Vatan Aksoy Tezer
+
+2.1.4 (2021-05-31)
+------------------
+
+2.1.3 (2021-05-22)
+------------------
+
+2.1.2 (2021-04-20)
+------------------
+
+2.1.1 (2021-04-12)
+------------------
+* Fix EXPORT install in CMake (`#372 <https://github.com/ros-planning/moveit2/issues/372>`_)
+* ActionBasedControllerHandle: fix dangling reference in case of timeout
+* [fix] Export libs for MoveGroup capabilities and MoveItSimpleControllerManager (`#344 <https://github.com/ros-planning/moveit2/issues/344>`_)
+* MTC compatibility fixes (`#323 <https://github.com/ros-planning/moveit2/issues/323>`_)
+* Replace workaround for controllerDoneCallback with promise/future
+* moveit_simple_controller_manager: Fix waiting for execution
+* Fix repo URLs in package.xml files
+* Contributors: Boston Cleek, Henning Kayser, Jafar Abdi, Tyler Weaver
+
+2.1.0 (2020-11-23)
+------------------
+
+2.0.0 (2020-02-17)
+------------------
+* [improve] MoveItSimpleControllerManager refactor parameter lookup
+* [fix] Fix plugin install of MoveItSimpleControllerManager
+* [port] Port moveit_simple_controller_manager to ROS 2 (`#158 <https://github.com/ros-planning/moveit2/issues/158>`_)
+* Contributors: Henning Kayser, Jafar Abdi
+
+1.1.1 (2020-10-13)
+------------------
+* [maint] Add comment to MOVEIT_CLASS_FORWARD (`#2315 <https://github.com/ros-planning/moveit/issues/2315>`_)
+* Contributors: Felix von Drigalski
+
+1.1.0 (2020-09-04)
+------------------
+* [feature] Optional cpp version setting (`#2166 <https://github.com/ros-planning/moveit/issues/2166>`_)
+* [feature] Allow different controllers for execution `#1832 <https://github.com/ros-planning/moveit/issues/1832>`_)
+* [feature] ControllerManager: wait for done-callback (`#1783 <https://github.com/ros-planning/moveit/issues/1783>`_)
+* [feature] Use CMAKE_CXX_STANDARD to enforce c++14 for portability (`#1607 <https://github.com/ros-planning/moveit/issues/1607>`_)
+* [fix] Various fixes for upcoming Noetic release (`#2180 <https://github.com/ros-planning/moveit/issues/2180>`_)
+* [fix] Fix errors: catkin_lint 1.6.7 (`#1987 <https://github.com/ros-planning/moveit/issues/1987>`_)
+* [fix] Fix compiler warnings (`#1773 <https://github.com/ros-planning/moveit/issues/1773>`_)
+* [fix] Fix binary artifact install locations. (`#1575 <https://github.com/ros-planning/moveit/issues/1575>`_)
+* [fix] add missing space to log (`#1477 <https://github.com/ros-planning/moveit/issues/1477>`_)
+* [maint] clang-tidy fixes (`#2050 <https://github.com/ros-planning/moveit/issues/2050>`_, `#1419 <https://github.com/ros-planning/moveit/issues/1419>`_)
+* [maint] Switch from include guards to pragma once (`#1615 <https://github.com/ros-planning/moveit/issues/1615>`_)
+* [maint] Remove ! from MoveIt name (`#1590 <https://github.com/ros-planning/moveit/issues/1590>`_)
+* Contributors: Dave Coleman, Henning Kayser, Jonathan Binney, Leroy Rügemer, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan, llach
+
+1.0.6 (2020-08-19)
+------------------
+* [maint] Migrate to clang-format-10
+* Contributors: Robert Haschke
+
+1.0.5 (2020-07-08)
+------------------
+
+1.0.4 (2020-05-30)
+------------------
+
+1.0.3 (2020-04-26)
+------------------
+* [fix]   Handle "default" parameter in MoveitControllerManagers
+  MoveIt{Fake|Simple}ControllerManager::getControllerState() now correctly returns current state
+* [maint] Fix errors: catkin_lint 1.6.7 (`#1987 <https://github.com/ros-planning/moveit/issues/1987>`_)
+* [maint] Windows build: Fix binary artifact install locations. (`#1575 <https://github.com/ros-planning/moveit/issues/1575>`_)
+* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (`#1607 <https://github.com/ros-planning/moveit/issues/1607>`_)
+* [fix]   `ControllerManager`: wait for done-callback (`#1783 <https://github.com/ros-planning/moveit/issues/1783>`_)
+* Contributors: Robert Haschke, Sean Yen, Luca Lach
+
+1.0.2 (2019-06-28)
+------------------
+
+1.0.1 (2019-03-08)
+------------------
+* [improve] Apply clang tidy fix to entire code base (Part 1) (`#1366 <https://github.com/ros-planning/moveit/issues/1366>`_)
+* Contributors: Yu, Yan
+
+1.0.0 (2019-02-24)
+------------------
+* [maintenance] cleanup SimpleControllerManager https://github.com/ros-planning/moveit/pull/1352
+* Contributors: Robert Haschke
+
+0.10.8 (2018-12-24)
+-------------------
+
+0.10.7 (2018-12-13)
+-------------------
+
+0.10.6 (2018-12-09)
+-------------------
+* [maintenance] Code Cleanup (`#1196 <https://github.com/ros-planning/moveit/issues/1196>`_)
+* Contributors: Robert Haschke
+
+0.10.5 (2018-11-01)
+-------------------
+
+0.10.4 (2018-10-29)
+-------------------
+
+0.10.3 (2018-10-29)
+-------------------
+
+0.10.2 (2018-10-24)
+-------------------
+* [maintenance] various compiler warnings (`#1038 <https://github.com/ros-planning/moveit/issues/1038>`_)
+* [maintenance] add minimum required pluginlib version (`#927 <https://github.com/ros-planning/moveit/issues/927>`_)
+* Contributors: Mikael Arguedas, Mohmmad Ayman, Robert Haschke, mike lautman
+
+0.10.1 (2018-05-25)
+-------------------
+* switch to ROS_LOGGER from CONSOLE_BRIDGE (`#874 <https://github.com/ros-planning/moveit/issues/874>`_)
+* Contributors: Mikael Arguedas, Xiaojian Ma
+
+0.9.11 (2017-12-25)
+-------------------
+
+0.9.10 (2017-12-09)
+-------------------
+* [capability][kinetic onward] optionally wait for controllers indefinitely (`#695 <https://github.com/ros-planning/moveit/issues/695>`_)
+* Contributors: Bruno Brito, Michael Görner
+
+0.9.9 (2017-08-06)
+------------------
+
+0.9.8 (2017-06-21)
+------------------
+* [fix] include order (`#529 <https://github.com/ros-planning/moveit/issues/529>`_)
+* Contributors: Michael Goerner
+
+0.9.7 (2017-06-05)
+------------------
+
+0.9.6 (2017-04-12)
+------------------
+
+0.9.5 (2017-03-08)
+------------------
+* [fix][moveit_ros_warehouse] gcc6 build error `#423 <https://github.com/ros-planning/moveit/pull/423>`_
+* [enhancement] Remove "catch (...)" instances, catch std::exception instead of std::runtime_error (`#445 <https://github.com/ros-planning/moveit/issues/445>`_)
+* Contributors: Bence Magyar, Dave Coleman
+
+0.9.4 (2017-02-06)
+------------------
+* [fix] assertion error when result not returned (`#378 <https://github.com/ros-planning/moveit/issues/378>`_)
+* [maintenance] clang-format upgraded to 3.8 (`#367 <https://github.com/ros-planning/moveit/issues/367>`_)
+* Contributors: Dave Coleman, Michael Ferguson
+
+0.9.3 (2016-11-16)
+------------------
+
+0.5.7 (2016-01-30)
+------------------
+* expose headers of moveit_simple_controller_manager
+* Removed redundant logging information
+* More informative warning message about multi-dof trajectories.
+* Contributors: Dave Coleman, Dave Hershberger, Mathias Lüdtke
+
+0.5.6 (2014-03-23)
+------------------
+* Allow simple controller manager to ignore virtual joints without failing
+* Contributors: Dave Coleman
+
+0.5.5 (2013-09-30)
+------------------
+* properly fill in the gripper command effort
+* allow trajectories with >1 points, use the last point of any trajectory
+* added better error reporting for FollowJointTrajectoryControllers
+
+0.5.4 (2013-09-24)
+------------------
+
+0.5.3 (2013-09-23)
+------------------
+* make things a bit more robust
+* make headers and author definitions aligned the same way; white space fixes
+* fix `#1 <https://github.com/ros-planning/moveit_plugins/issues/1>`_
+
+0.5.1 (2013-07-30)
+------------------
+* ns parameter is now action_ns, get rid of defaults
+
+0.5.0 (2013-07-16)
+------------------
+* white space fixes (tabs are now spaces)
+
+0.4.1 (2013-07-03)
+------------------
+* minor updates to package.xml
+
+0.4.0 (2013-06-06)
+------------------
+* debs look good, bump to 0.4.0
+
+0.1.0 (2013-06-05)
+------------------
+* add metapackage, clean up build in controller manager
+* remove the now dead loaded controller stuff
+* break out follow/gripper into separate headers
+* initial working version

--- a/stretch_simple_controller_manager/CMakeLists.txt
+++ b/stretch_simple_controller_manager/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.10.2)
+project(stretch_simple_controller_manager)
+
+# Common cmake code applied to all moveit packages
+find_package(moveit_common REQUIRED)
+moveit_package()
+
+find_package(ament_cmake REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(control_msgs REQUIRED)
+find_package(rclcpp_action REQUIRED)
+
+# Finds Boost Components
+include(ConfigExtras.cmake)
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  control_msgs
+  rclcpp
+  rclcpp_action
+  moveit_core
+  pluginlib
+)
+
+include_directories(
+  include
+)
+
+add_library(${PROJECT_NAME} SHARED
+  src/moveit_simple_controller_manager.cpp
+  src/follow_joint_trajectory_controller_handle.cpp
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+
+ament_target_dependencies(${PROJECT_NAME}
+  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+  Boost
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+install(DIRECTORY include/ DESTINATION include)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+  Boost
+)
+
+pluginlib_export_plugin_description_file(moveit_core moveit_simple_controller_manager_plugin_description.xml)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+
+  # These don't pass yet, disable them for now
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cppcheck_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  set(ament_cmake_uncrustify_FOUND TRUE)
+
+  # Run all lint tests in package.xml except those listed above
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package(CONFIG_EXTRAS ConfigExtras.cmake)

--- a/stretch_simple_controller_manager/ConfigExtras.cmake
+++ b/stretch_simple_controller_manager/ConfigExtras.cmake
@@ -1,0 +1,3 @@
+# Extras module needed for dependencies to find boost components
+
+find_package(Boost REQUIRED thread)

--- a/stretch_simple_controller_manager/include/stretch_simple_controller_manager/action_based_controller_handle.h
+++ b/stretch_simple_controller_manager/include/stretch_simple_controller_manager/action_based_controller_handle.h
@@ -1,0 +1,226 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Unbounded Robotics Inc.
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Michael Ferguson, Ioan Sucan, E. Gil Jones */
+
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <moveit/controller_manager/controller_manager.h>
+#include <moveit/macros/class_forward.h>
+#include <memory>
+
+namespace stretch_simple_controller_manager
+{
+/*
+ * This exist solely to inject addJoint/getJoints into base non-templated class.
+ */
+class ActionBasedControllerHandleBase : public moveit_controller_manager::MoveItControllerHandle
+{
+public:
+  ActionBasedControllerHandleBase(const std::string& name, const std::string& logger_name)
+    : moveit_controller_manager::MoveItControllerHandle(name), LOGGER(rclcpp::get_logger(logger_name))
+  {
+  }
+
+  virtual void addJoint(const std::string& name) = 0;
+  virtual void getJoints(std::vector<std::string>& joints) = 0;
+  // TODO(JafarAbdi): Revise parameter lookup
+  //  virtual void configure(XmlRpc::XmlRpcValue& /* config */)
+  //  {
+  //  }
+
+protected:
+  const rclcpp::Logger LOGGER;
+};
+
+MOVEIT_CLASS_FORWARD(
+    ActionBasedControllerHandleBase);  // Defines ActionBasedControllerHandleBasePtr, ConstPtr, WeakPtr... etc
+
+/*
+ * This is a simple base class, which handles all of the action creation/etc
+ */
+template <typename T>
+class ActionBasedControllerHandle : public ActionBasedControllerHandleBase
+{
+public:
+  ActionBasedControllerHandle(const rclcpp::Node::SharedPtr& node, const std::string& name, const std::string& ns,
+                              const std::string& logger_name)
+    : ActionBasedControllerHandleBase(name, logger_name), node_(node), done_(true), namespace_(ns)
+  {
+    controller_action_client_ = rclcpp_action::create_client<T>(node_, getActionName());
+
+    unsigned int attempts = 0;
+    double timeout;
+    node_->get_parameter_or("trajectory_execution.controller_connection_timeout", timeout, 15.0);
+
+    if (timeout == 0.0)
+    {
+      while (rclcpp::ok() && !controller_action_client_->wait_for_action_server(std::chrono::seconds(5)))
+      {
+        RCLCPP_WARN_STREAM(LOGGER, "Waiting for " << getActionName() << " to come up");
+      }
+    }
+    else
+    {
+      while (rclcpp::ok() &&
+             !controller_action_client_->wait_for_action_server(std::chrono::duration<double>(timeout / 3)) &&
+             ++attempts < 3)
+      {
+        RCLCPP_WARN_STREAM(LOGGER, "Waiting for " << getActionName() << " to come up");
+      }
+    }
+    if (!controller_action_client_->action_server_is_ready())
+    {
+      RCLCPP_ERROR_STREAM(LOGGER, "Action client not connected: " << getActionName());
+      controller_action_client_.reset();
+    }
+
+    last_exec_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
+  }
+
+  bool isConnected() const
+  {
+    return static_cast<bool>(controller_action_client_);
+  }
+
+  bool cancelExecution() override
+  {
+    if (!controller_action_client_)
+      return false;
+    if (!done_)
+    {
+      RCLCPP_INFO_STREAM(LOGGER, "Cancelling execution for " << name_);
+      auto cancel_result_future = controller_action_client_->async_cancel_goal(current_goal_);
+
+      const auto& result = cancel_result_future.get();
+      if (!result)
+        RCLCPP_ERROR(LOGGER, "Failed to cancel goal");
+
+      last_exec_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
+      done_ = true;
+    }
+    return true;
+  }
+
+  virtual void
+  controllerDoneCallback(const typename rclcpp_action::ClientGoalHandle<T>::WrappedResult& wrapped_result) = 0;
+
+  bool waitForExecution(const rclcpp::Duration& timeout = rclcpp::Duration::from_seconds(-1.0)) override
+  {
+    auto result_callback_done = std::make_shared<std::promise<bool>>();
+    auto result_future = controller_action_client_->async_get_result(
+        current_goal_, [this, result_callback_done](const auto& wrapped_result) {
+          controllerDoneCallback(wrapped_result);
+          result_callback_done->set_value(true);
+        });
+    if (timeout < std::chrono::nanoseconds(0))
+    {
+      result_future.wait();
+    }
+    else
+    {
+      std::future_status status = result_future.wait_for(timeout.to_chrono<std::chrono::duration<double>>());
+      if (status == std::future_status::timeout)
+      {
+        RCLCPP_WARN(LOGGER, "waitForExecution timed out");
+        return false;
+      }
+    }
+    // To accommodate for the delay after the future for the result is ready and the time controllerDoneCallback takes to finish
+    result_callback_done->get_future().wait();
+    return true;
+  }
+
+  moveit_controller_manager::ExecutionStatus getLastExecutionStatus() override
+  {
+    return last_exec_;
+  }
+
+  void addJoint(const std::string& name) override
+  {
+    joints_.push_back(name);
+  }
+
+  void getJoints(std::vector<std::string>& joints) override
+  {
+    joints = joints_;
+  }
+
+protected:
+  const rclcpp::Node::SharedPtr node_;
+  std::string getActionName() const
+  {
+    if (namespace_.empty())
+      return name_;
+    else
+      return name_ + "/" + namespace_;
+  }
+
+  void finishControllerExecution(const rclcpp_action::ResultCode& state)
+  {
+    RCLCPP_DEBUG_STREAM(LOGGER, "Controller " << name_ << " is done with state " << static_cast<int>(state));
+    if (state == rclcpp_action::ResultCode::SUCCEEDED)
+      last_exec_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
+    else if (state == rclcpp_action::ResultCode::ABORTED)
+      last_exec_ = moveit_controller_manager::ExecutionStatus::ABORTED;
+    else if (state == rclcpp_action::ResultCode::CANCELED)
+      last_exec_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
+    else if (state == rclcpp_action::ResultCode::UNKNOWN)
+      last_exec_ = moveit_controller_manager::ExecutionStatus::UNKNOWN;
+    else
+      last_exec_ = moveit_controller_manager::ExecutionStatus::FAILED;
+    done_ = true;
+  }
+
+  /* execution status */
+  moveit_controller_manager::ExecutionStatus last_exec_;
+  bool done_;
+
+  /* the controller namespace, for instance, topics will map to name/ns/goal,
+   * name/ns/result, etc */
+  std::string namespace_;
+
+  /* the joints controlled by this controller */
+  std::vector<std::string> joints_;
+
+  /* action client */
+  typename rclcpp_action::Client<T>::SharedPtr controller_action_client_;
+  /* Current goal that have been sent to the action server */
+  typename rclcpp_action::ClientGoalHandle<T>::SharedPtr current_goal_;
+};
+
+}  // end namespace stretch_simple_controller_manager

--- a/stretch_simple_controller_manager/include/stretch_simple_controller_manager/follow_joint_trajectory_controller_handle.h
+++ b/stretch_simple_controller_manager/include/stretch_simple_controller_manager/follow_joint_trajectory_controller_handle.h
@@ -1,0 +1,78 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Unbounded Robotics Inc.
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Michael Ferguson, Ioan Sucan, E. Gil Jones */
+
+#pragma once
+
+#include <stretch_simple_controller_manager/action_based_controller_handle.h>
+#include <control_msgs/action/follow_joint_trajectory.hpp>
+#include <control_msgs/msg/joint_tolerance.hpp>
+#include <functional>
+
+namespace stretch_simple_controller_manager
+{
+/*
+ * This is generally used for arms, but could also be used for multi-dof hands,
+ * or anything using a control_mgs/FollowJointTrajectoryAction.
+ */
+class FollowJointTrajectoryControllerHandle
+  : public ActionBasedControllerHandle<control_msgs::action::FollowJointTrajectory>
+{
+public:
+  FollowJointTrajectoryControllerHandle(const rclcpp::Node::SharedPtr& node, const std::string& name,
+                                        const std::string& action_ns)
+    : ActionBasedControllerHandle<control_msgs::action::FollowJointTrajectory>(
+          node, name, action_ns, "moveit.simple_controller_manager.follow_joint_trajectory_controller_handle")
+  {
+  }
+
+  bool sendTrajectory(const moveit_msgs::msg::RobotTrajectory& trajectory) override;
+
+  // TODO(JafarAbdi): Revise parameter lookup
+  // void configure(XmlRpc::XmlRpcValue& config) override;
+
+protected:
+  static control_msgs::msg::JointTolerance& getTolerance(std::vector<control_msgs::msg::JointTolerance>& tolerances,
+                                                         const std::string& name);
+
+  void controllerDoneCallback(
+      const rclcpp_action::ClientGoalHandle<control_msgs::action::FollowJointTrajectory>::WrappedResult& wrapped_result)
+      override;
+
+  control_msgs::action::FollowJointTrajectory::Goal goal_template_;
+};
+
+}  // end namespace stretch_simple_controller_manager

--- a/stretch_simple_controller_manager/include/stretch_simple_controller_manager/gripper_controller_handle.h
+++ b/stretch_simple_controller_manager/include/stretch_simple_controller_manager/gripper_controller_handle.h
@@ -1,0 +1,218 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Unbounded Robotics Inc.
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Michael Ferguson, Ioan Sucan, E. Gil Jones */
+
+#pragma once
+
+#include <stretch_simple_controller_manager/action_based_controller_handle.h>
+#include <control_msgs/action/gripper_command.hpp>
+#include <set>
+
+namespace stretch_simple_controller_manager
+{
+/*
+ * This is an interface for a gripper using control_msgs/GripperCommandAction
+ * action interface (single DOF).
+ */
+class GripperControllerHandle : public ActionBasedControllerHandle<control_msgs::action::GripperCommand>
+{
+public:
+  /* Topics will map to name/ns/goal, name/ns/result, etc */
+  GripperControllerHandle(const rclcpp::Node::SharedPtr& node, const std::string& name, const std::string& ns)
+    : ActionBasedControllerHandle<control_msgs::action::GripperCommand>(
+          node, name, ns, "moveit.simple_controller_manager.gripper_controller_handle")
+    , allow_failure_(false)
+    , parallel_jaw_gripper_(false)
+  {
+  }
+
+  bool sendTrajectory(const moveit_msgs::msg::RobotTrajectory& trajectory) override
+  {
+    RCLCPP_DEBUG_STREAM(LOGGER, "Received new trajectory for " << name_);
+
+    if (!controller_action_client_)
+      return false;
+
+    if (!trajectory.multi_dof_joint_trajectory.points.empty())
+    {
+      RCLCPP_ERROR(LOGGER, "Gripper cannot execute multi-dof trajectories.");
+      return false;
+    }
+
+    if (trajectory.joint_trajectory.points.empty())
+    {
+      RCLCPP_ERROR(LOGGER, "GripperController requires at least one joint trajectory point.");
+      return false;
+    }
+
+    // TODO(JafarAbdi): Enable when msg streaming operator is available
+    // if (trajectory.joint_trajectory.points.size() > 1)
+    // {
+    //   RCLCPP_DEBUG_STREAM(LOGGER, "Trajectory: " << trajectory.joint_trajectory);
+    // }
+
+    if (trajectory.joint_trajectory.joint_names.empty())
+    {
+      RCLCPP_ERROR(LOGGER, "No joint names specified");
+      return false;
+    }
+
+    std::vector<std::size_t> gripper_joint_indexes;
+    for (std::size_t i = 0; i < trajectory.joint_trajectory.joint_names.size(); ++i)
+    {
+      if (command_joints_.find(trajectory.joint_trajectory.joint_names[i]) != command_joints_.end())
+      {
+        gripper_joint_indexes.push_back(i);
+        if (!parallel_jaw_gripper_)
+          break;
+      }
+    }
+
+    if (gripper_joint_indexes.empty())
+    {
+      RCLCPP_WARN(LOGGER, "No command_joint was specified for the MoveIt controller gripper handle. \
+                      Please see GripperControllerHandle::addCommandJoint() and \
+                      GripperControllerHandle::setCommandJoint(). Assuming index 0.");
+      gripper_joint_indexes.push_back(0);
+    }
+
+    // goal to be sent
+    control_msgs::action::GripperCommand::Goal goal;
+    goal.command.position = 0.0;
+    goal.command.max_effort = 0.0;
+
+    // send last point
+    int tpoint = trajectory.joint_trajectory.points.size() - 1;
+    RCLCPP_DEBUG(LOGGER, "Sending command from trajectory point %d", tpoint);
+
+    // fill in goal from last point
+    for (std::size_t idx : gripper_joint_indexes)
+    {
+      if (trajectory.joint_trajectory.points[tpoint].positions.size() <= idx)
+      {
+        RCLCPP_ERROR(LOGGER, "GripperController expects a joint trajectory with one \
+                         point that specifies at least the position of joint \
+                         '%s', but insufficient positions provided",
+                     trajectory.joint_trajectory.joint_names[idx].c_str());
+        return false;
+      }
+      goal.command.position += trajectory.joint_trajectory.points[tpoint].positions[idx];
+
+      if (trajectory.joint_trajectory.points[tpoint].effort.size() > idx)
+        goal.command.max_effort = trajectory.joint_trajectory.points[tpoint].effort[idx];
+    }
+    rclcpp_action::Client<control_msgs::action::GripperCommand>::SendGoalOptions send_goal_options;
+    // Active callback
+    send_goal_options.goal_response_callback =
+        [this](std::shared_future<rclcpp_action::Client<control_msgs::action::GripperCommand>::GoalHandle::SharedPtr>
+               /* unused-arg */) { RCLCPP_DEBUG_STREAM(LOGGER, name_ << " started execution"); };
+    // Send goal
+    auto current_goal_future = controller_action_client_->async_send_goal(goal, send_goal_options);
+    current_goal_ = current_goal_future.get();
+    if (!current_goal_)
+    {
+      RCLCPP_ERROR(LOGGER, "Goal was rejected by server");
+      return false;
+    }
+
+    done_ = false;
+    last_exec_ = moveit_controller_manager::ExecutionStatus::RUNNING;
+    return true;
+  }
+
+  void setCommandJoint(const std::string& name)
+  {
+    command_joints_.clear();
+    addCommandJoint(name);
+  }
+
+  void addCommandJoint(const std::string& name)
+  {
+    command_joints_.insert(name);
+  }
+
+  void allowFailure(bool allow)
+  {
+    allow_failure_ = allow;
+  }
+
+  void setParallelJawGripper(const std::string& left, const std::string& right)
+  {
+    addCommandJoint(left);
+    addCommandJoint(right);
+    parallel_jaw_gripper_ = true;
+  }
+
+private:
+  void controllerDoneCallback(
+      const rclcpp_action::ClientGoalHandle<control_msgs::action::GripperCommand>::WrappedResult& wrapped_result) override
+  {
+    if (wrapped_result.code == rclcpp_action::ResultCode::ABORTED && allow_failure_)
+      finishControllerExecution(rclcpp_action::ResultCode::SUCCEEDED);
+    else
+      finishControllerExecution(wrapped_result.code);
+  }
+
+  /*
+   * Some gripper drivers may indicate a failure if they do not close all the way when
+   * an object is in the gripper.
+   */
+  bool allow_failure_;
+
+  /*
+   * A common setup is where there are two joints that each move
+   * half the overall distance. Thus, the command to the gripper
+   * should be the sum of the two joint distances.
+   *
+   * When this is set, command_joints_ should be of size 2,
+   * and the command will be the sum of the two joints.
+   */
+  bool parallel_jaw_gripper_;
+
+  /*
+   * A GripperCommand message has only a single float64 for the
+   * "command", thus only a single joint angle can be sent -- however,
+   * due to the complexity of making grippers look correct in a URDF,
+   * they typically have >1 joints. The "command_joint" is the joint
+   * whose position value will be sent in the GripperCommand action. A
+   * set of names is provided for acceptable joint names. If any of
+   * the joints specified is found, the value corresponding to that
+   * joint is considered the command.
+   */
+  std::set<std::string> command_joints_;
+};  // namespace stretch_simple_controller_manager
+
+}  // end namespace stretch_simple_controller_manager

--- a/stretch_simple_controller_manager/moveit_simple_controller_manager_plugin_description.xml
+++ b/stretch_simple_controller_manager/moveit_simple_controller_manager_plugin_description.xml
@@ -1,0 +1,10 @@
+<library path="stretch_simple_controller_manager">
+
+  <class name="stretch_simple_controller_manager/MoveItSimpleControllerManager"
+         type="stretch_simple_controller_manager::MoveItSimpleControllerManager"
+         base_class_type="moveit_controller_manager::MoveItControllerManager">
+    <description>
+    </description>
+  </class>
+
+</library>

--- a/stretch_simple_controller_manager/package.xml
+++ b/stretch_simple_controller_manager/package.xml
@@ -1,0 +1,35 @@
+<package format="2">
+  <name>stretch_simple_controller_manager</name>
+  <version>2.3.0</version>
+  <description>A generic, simple controller manager plugin for MoveIt.</description>
+
+  <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
+
+  <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
+  <maintainer email="me@v4hn.de">Michael Görner</maintainer>
+  <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://moveit.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
+  <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
+
+  <depend>moveit_core</depend>
+  <depend>rclcpp</depend>
+  <depend version_gte="1.11.2">pluginlib</depend>
+  <depend>control_msgs</depend>
+  <depend>rclcpp_action</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <moveit_core plugin="${prefix}/moveit_simple_controller_manager_plugin_description.xml"/>
+  </export>
+
+</package>

--- a/stretch_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/stretch_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -1,0 +1,229 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Unbounded Robotics Inc.
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Michael Ferguson, Ioan Sucan, E. Gil Jones */
+
+#include <stretch_simple_controller_manager/follow_joint_trajectory_controller_handle.h>
+
+using namespace std::placeholders;
+
+namespace stretch_simple_controller_manager
+{
+bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::msg::RobotTrajectory& trajectory)
+{
+  RCLCPP_DEBUG_STREAM(LOGGER, "new trajectory to " << name_);
+
+  if (!controller_action_client_)
+    return false;
+
+  if (done_)
+    RCLCPP_INFO_STREAM(LOGGER, "sending trajectory to " << name_);
+  else
+    RCLCPP_INFO_STREAM(LOGGER, "sending continuation for the currently executed trajectory to " << name_);
+
+  control_msgs::action::FollowJointTrajectory::Goal goal = goal_template_;
+  goal.trajectory = trajectory.joint_trajectory;
+  goal.multi_dof_trajectory = trajectory.multi_dof_joint_trajectory;
+
+  rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::SendGoalOptions send_goal_options;
+  // Active callback
+  send_goal_options.goal_response_callback =
+      [this](
+          std::shared_future<rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::GoalHandle::SharedPtr>
+              future) {
+        RCLCPP_INFO_STREAM(LOGGER, name_ << " started execution");
+        const auto& goal_handle = future.get();
+        if (!goal_handle)
+          RCLCPP_WARN(LOGGER, "Goal request rejected");
+        else
+          RCLCPP_INFO(LOGGER, "Goal request accepted!");
+      };
+
+  done_ = false;
+  last_exec_ = moveit_controller_manager::ExecutionStatus::RUNNING;
+
+  // Send goal
+  auto current_goal_future = controller_action_client_->async_send_goal(goal, send_goal_options);
+  current_goal_ = current_goal_future.get();
+  if (!current_goal_)
+  {
+    RCLCPP_ERROR(LOGGER, "Goal was rejected by server");
+    return false;
+  }
+  return true;
+}
+
+// TODO(JafarAbdi): Revise parameter lookup
+// void FollowJointTrajectoryControllerHandle::configure(XmlRpc::XmlRpcValue& config)
+//{
+//  if (config.hasMember("path_tolerance"))
+//    configure(config["path_tolerance"], "path_tolerance", goal_template_.path_tolerance);
+//  if (config.hasMember("goal_tolerance"))
+//    configure(config["goal_tolerance"], "goal_tolerance", goal_template_.goal_tolerance);
+//  if (config.hasMember("goal_time_tolerance"))
+//    goal_template_.goal_time_tolerance = ros::Duration(parseDouble(config["goal_time_tolerance"]));
+//}
+
+namespace
+{
+enum ToleranceVariables
+{
+  POSITION,
+  VELOCITY,
+  ACCELERATION
+};
+template <ToleranceVariables>
+double& variable(control_msgs::msg::JointTolerance& msg);
+
+template <>
+inline double& variable<POSITION>(control_msgs::msg::JointTolerance& msg)
+{
+  return msg.position;
+}
+template <>
+inline double& variable<VELOCITY>(control_msgs::msg::JointTolerance& msg)
+{
+  return msg.velocity;
+}
+template <>
+inline double& variable<ACCELERATION>(control_msgs::msg::JointTolerance& msg)
+{
+  return msg.acceleration;
+}
+
+static std::map<ToleranceVariables, std::string> VAR_NAME = { { POSITION, "position" },
+                                                              { VELOCITY, "velocity" },
+                                                              { ACCELERATION, "acceleration" } };
+static std::map<ToleranceVariables, decltype(&variable<POSITION>)> VAR_ACCESS = { { POSITION, &variable<POSITION> },
+                                                                                  { VELOCITY, &variable<VELOCITY> },
+                                                                                  { ACCELERATION,
+                                                                                    &variable<ACCELERATION> } };
+
+const char* errorCodeToMessage(int error_code)
+{
+  switch (error_code)
+  {
+    case control_msgs::action::FollowJointTrajectory::Result::SUCCESSFUL:
+      return "SUCCESSFUL";
+    case control_msgs::action::FollowJointTrajectory::Result::INVALID_GOAL:
+      return "INVALID_GOAL";
+    case control_msgs::action::FollowJointTrajectory::Result::INVALID_JOINTS:
+      return "INVALID_JOINTS";
+    case control_msgs::action::FollowJointTrajectory::Result::OLD_HEADER_TIMESTAMP:
+      return "OLD_HEADER_TIMESTAMP";
+    case control_msgs::action::FollowJointTrajectory::Result::PATH_TOLERANCE_VIOLATED:
+      return "PATH_TOLERANCE_VIOLATED";
+    case control_msgs::action::FollowJointTrajectory::Result::GOAL_TOLERANCE_VIOLATED:
+      return "GOAL_TOLERANCE_VIOLATED";
+    default:
+      return "unknown error";
+  }
+}
+}  // namespace
+
+// TODO(JafarAbdi): Revise parameter lookup
+// void FollowJointTrajectoryControllerHandle::configure(XmlRpc::XmlRpcValue& config, const std::string& config_name,
+//                                                      std::vector<control_msgs::JointTolerance>& tolerances)
+//{
+//  if (isStruct(config))  // config should be either a struct of position, velocity, acceleration
+//  {
+//    for (ToleranceVariables var : { POSITION, VELOCITY, ACCELERATION })
+//    {
+//      if (!config.hasMember(VAR_NAME[var]))
+//        continue;
+//      XmlRpc::XmlRpcValue values = config[VAR_NAME[var]];
+//      if (isArray(values, joints_.size()))
+//      {
+//        size_t i = 0;
+//        for (const auto& joint_name : joints_)
+//          VAR_ACCESS[var](getTolerance(tolerances, joint_name)) = parseDouble(values[i++]);
+//      }
+//      else
+//      {  // use common value for all joints
+//        double value = parseDouble(values);
+//        for (const auto& joint_name : joints_)
+//          VAR_ACCESS[var](getTolerance(tolerances, joint_name)) = value;
+//      }
+//    }
+//  }
+//  else if (isArray(config))  // or an array of JointTolerance msgs
+//  {
+//    for (int i = 0; i < config.size(); ++i)  // NOLINT(modernize-loop-convert)
+//    {
+//      control_msgs::JointTolerance& tol = getTolerance(tolerances, config[i]["name"]);
+//      for (ToleranceVariables var : { POSITION, VELOCITY, ACCELERATION })
+//      {
+//        if (!config[i].hasMember(VAR_NAME[var]))
+//          continue;
+//        VAR_ACCESS[var](tol) = parseDouble(config[i][VAR_NAME[var]]);
+//      }
+//    }
+//  }
+//  else
+//    ROS_WARN_STREAM_NAMED(LOGNAME, "Invalid " << config_name);
+//}
+
+control_msgs::msg::JointTolerance&
+FollowJointTrajectoryControllerHandle::getTolerance(std::vector<control_msgs::msg::JointTolerance>& tolerances,
+                                                    const std::string& name)
+{
+  auto it = std::lower_bound(tolerances.begin(), tolerances.end(), name,
+                             [](const control_msgs::msg::JointTolerance& lhs, const std::string& rhs) {
+                               return lhs.name < rhs;
+                             });
+  if (it == tolerances.cend() || it->name != name)
+  {  // insert new entry if not yet available
+    it = tolerances.insert(it, control_msgs::msg::JointTolerance());
+    it->name = name;
+  }
+  return *it;
+}
+
+void FollowJointTrajectoryControllerHandle::controllerDoneCallback(
+    const rclcpp_action::ClientGoalHandle<control_msgs::action::FollowJointTrajectory>::WrappedResult& wrapped_result)
+{
+  // Output custom error message for FollowJointTrajectoryResult if necessary
+  if (!wrapped_result.result)
+    RCLCPP_WARN_STREAM(LOGGER, "Controller " << name_ << " done, no result returned");
+  else if (wrapped_result.result->error_code == control_msgs::action::FollowJointTrajectory::Result::SUCCESSFUL)
+    RCLCPP_INFO_STREAM(LOGGER, "Controller " << name_ << " successfully finished");
+  else
+    RCLCPP_WARN_STREAM(LOGGER, "Controller " << name_ << " failed with error "
+                                             << errorCodeToMessage(wrapped_result.result->error_code) << ": "
+                                             << wrapped_result.result->error_string);
+  finishControllerExecution(wrapped_result.code);
+}
+
+}  // end namespace stretch_simple_controller_manager

--- a/stretch_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/stretch_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -1,0 +1,257 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Unbounded Robotics Inc.
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Michael Ferguson, Ioan Sucan, E. Gil Jones */
+
+#include <rclcpp/rclcpp.hpp>
+#include <stretch_simple_controller_manager/action_based_controller_handle.h>
+#include <stretch_simple_controller_manager/gripper_controller_handle.h>
+#include <stretch_simple_controller_manager/follow_joint_trajectory_controller_handle.h>
+#include <boost/algorithm/string/join.hpp>
+#include <pluginlib/class_list_macros.hpp>
+#include <algorithm>
+#include <map>
+
+namespace stretch_simple_controller_manager
+{
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.plugins.stretch_simple_controller_manager");
+static const std::string PARAM_BASE_NAME = "stretch_simple_controller_manager";
+class MoveItSimpleControllerManager : public moveit_controller_manager::MoveItControllerManager
+{
+public:
+  MoveItSimpleControllerManager() = default;
+
+  ~MoveItSimpleControllerManager() override = default;
+
+  void initialize(const rclcpp::Node::SharedPtr& node) override
+  {
+    node_ = node;
+    if (!node_->has_parameter(PARAM_BASE_NAME + ".controller_names"))
+    {
+      RCLCPP_ERROR_STREAM(LOGGER, "No controller_names specified.");
+      return;
+    }
+    rclcpp::Parameter controller_names_param;
+    node_->get_parameter(PARAM_BASE_NAME + ".controller_names", controller_names_param);
+    if (controller_names_param.get_type() != rclcpp::ParameterType::PARAMETER_STRING_ARRAY)
+    {
+      RCLCPP_ERROR(LOGGER, "Parameter controller_names should be specified as a string array");
+      return;
+    }
+    std::vector<std::string> controller_names = controller_names_param.as_string_array();
+    /* actually create each controller */
+    for (const std::string& controller_name : controller_names)
+    {
+      try
+      {
+        std::string action_ns;
+        if (!node_->get_parameter(PARAM_BASE_NAME + "." + controller_name + ".action_ns", action_ns))
+        {
+          RCLCPP_ERROR_STREAM(LOGGER, "No action namespace specified for controller " << controller_name);
+          RCLCPP_ERROR_STREAM(LOGGER, "Parameter: " << (PARAM_BASE_NAME + "." + controller_name + ".action"));
+          continue;
+        }
+
+        std::string type;
+        if (!node_->get_parameter(PARAM_BASE_NAME + "." + controller_name + ".type", type))
+        {
+          RCLCPP_ERROR_STREAM(LOGGER, "No type specified for controller " << controller_name);
+          continue;
+        }
+
+        std::vector<std::string> controller_joints;
+        if (!node_->get_parameter(PARAM_BASE_NAME + "." + controller_name + ".joints", controller_joints) ||
+            controller_joints.empty())
+        {
+          RCLCPP_ERROR_STREAM(LOGGER, "No joints specified for controller " << controller_name);
+          continue;
+        }
+
+        ActionBasedControllerHandleBasePtr new_handle;
+        if (type == "GripperCommand")
+        {
+          new_handle = std::make_shared<GripperControllerHandle>(node_, controller_name, action_ns);
+          if (static_cast<GripperControllerHandle*>(new_handle.get())->isConnected())
+          {
+            bool parallel_gripper = false;
+            if (node_->get_parameter(PARAM_BASE_NAME + ".parallel", parallel_gripper) && parallel_gripper)
+            {
+              if (controller_joints.size() != 2)
+              {
+                RCLCPP_ERROR_STREAM(LOGGER, "Parallel Gripper requires exactly two joints, " << controller_joints.size()
+                                                                                             << " are specified");
+                continue;
+              }
+              static_cast<GripperControllerHandle*>(new_handle.get())
+                  ->setParallelJawGripper(controller_joints[0], controller_joints[1]);
+            }
+            else
+            {
+              std::string command_joint;
+              if (!node_->get_parameter(PARAM_BASE_NAME + ".command_joint", command_joint))
+                command_joint = controller_joints[0];
+
+              static_cast<GripperControllerHandle*>(new_handle.get())->setCommandJoint(command_joint);
+            }
+
+            bool allow_failure;
+            node_->get_parameter_or(PARAM_BASE_NAME + ".allow_failure", allow_failure, false);
+            static_cast<GripperControllerHandle*>(new_handle.get())->allowFailure(allow_failure);
+
+            RCLCPP_INFO_STREAM(LOGGER, "Added GripperCommand controller for " << controller_name);
+            controllers_[controller_name] = new_handle;
+          }
+        }
+        else if (type == "FollowJointTrajectory")
+        {
+          auto h = new FollowJointTrajectoryControllerHandle(node_, controller_name, action_ns);
+          new_handle.reset(h);
+          if (h->isConnected())
+          {
+            RCLCPP_INFO_STREAM(LOGGER, "Added FollowJointTrajectory controller for " << controller_name);
+            controllers_[controller_name] = new_handle;
+          }
+        }
+        else
+        {
+          RCLCPP_ERROR_STREAM(LOGGER, "Unknown controller type: " << type);
+          continue;
+        }
+        if (!controllers_[controller_name])
+        {
+          controllers_.erase(controller_name);
+          continue;
+        }
+
+        moveit_controller_manager::MoveItControllerManager::ControllerState state;
+        node_->get_parameter_or(PARAM_BASE_NAME + "." + controller_name + ".default", state.default_, false);
+        state.active_ = true;
+
+        controller_states_[controller_name] = state;
+
+        /* add list of joints, used by controller manager and MoveIt */
+        for (const std::string& controller_joint : controller_joints)
+          new_handle->addJoint(controller_joint);
+      }
+      catch (...)
+      {
+        RCLCPP_ERROR_STREAM(LOGGER, "Caught unknown exception while parsing controller information");
+      }
+    }
+  }
+  /*
+   * Get a controller, by controller name (which was specified in the controllers.yaml
+   */
+  moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string& name) override
+  {
+    std::map<std::string, ActionBasedControllerHandleBasePtr>::const_iterator it = controllers_.find(name);
+    if (it != controllers_.end())
+      return static_cast<moveit_controller_manager::MoveItControllerHandlePtr>(it->second);
+    else
+      RCLCPP_FATAL_STREAM(LOGGER, "No such controller: " << name);
+    return moveit_controller_manager::MoveItControllerHandlePtr();
+  }
+
+  /*
+   * Get the list of controller names.
+   */
+  void getControllersList(std::vector<std::string>& names) override
+  {
+    for (std::map<std::string, ActionBasedControllerHandleBasePtr>::const_iterator it = controllers_.begin();
+         it != controllers_.end(); ++it)
+      names.push_back(it->first);
+    RCLCPP_INFO_STREAM(LOGGER, "Returned " << names.size() << " controllers in list");
+  }
+
+  /*
+   * This plugin assumes that all controllers are already active -- and if they are not, well, it has no way to deal
+   * with it anyways!
+   */
+  void getActiveControllers(std::vector<std::string>& names) override
+  {
+    getControllersList(names);
+  }
+
+  /*
+   * Controller must be loaded to be active, see comment above about active controllers...
+   */
+  virtual void getLoadedControllers(std::vector<std::string>& names)
+  {
+    getControllersList(names);
+  }
+
+  /*
+   * Get the list of joints that a controller can control.
+   */
+  void getControllerJoints(const std::string& name, std::vector<std::string>& joints) override
+  {
+    std::map<std::string, ActionBasedControllerHandleBasePtr>::const_iterator it = controllers_.find(name);
+    if (it != controllers_.end())
+    {
+      it->second->getJoints(joints);
+    }
+    else
+    {
+      RCLCPP_WARN(LOGGER,
+                  "The joints for controller '%s' are not known. Perhaps the controller configuration is "
+                  "not loaded on the param server?",
+                  name.c_str());
+      joints.clear();
+    }
+  }
+
+  moveit_controller_manager::MoveItControllerManager::ControllerState
+  getControllerState(const std::string& name) override
+  {
+    return controller_states_[name];
+  }
+
+  /* Cannot switch our controllers */
+  bool switchControllers(const std::vector<std::string>& /* activate */,
+                         const std::vector<std::string>& /* deactivate */) override
+  {
+    return false;
+  }
+
+protected:
+  rclcpp::Node::SharedPtr node_;
+  std::map<std::string, ActionBasedControllerHandleBasePtr> controllers_;
+  std::map<std::string, moveit_controller_manager::MoveItControllerManager::ControllerState> controller_states_;
+};
+
+}  // end namespace stretch_simple_controller_manager
+
+PLUGINLIB_EXPORT_CLASS(stretch_simple_controller_manager::MoveItSimpleControllerManager,
+                       moveit_controller_manager::MoveItControllerManager);


### PR DESCRIPTION
Should revert to using MoveIt Simple Controller Manager when updated binaries release.