### PR TITLE
Add support for RPlidar in ROS 2

### DIFF
--- a/stretch_core/config/laser_filter_params.yaml
+++ b/stretch_core/config/laser_filter_params.yaml
@@ -1,0 +1,10 @@
+scan_to_scan_filter_chain:
+  ros__parameters:
+    filter1:
+      name: shadows
+      type: laser_filters/ScanShadowsFilter
+      params:
+        min_angle: 10.
+        max_angle: 170.
+        neighbors: 20
+        window: 1

--- a/stretch_core/launch/rplidar.launch.py
+++ b/stretch_core/launch/rplidar.launch.py
@@ -1,0 +1,53 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import LogInfo
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+configurable_parameters = [{'name': 'serial_port',      'default': '/dev/hello-lrf',   'description':"'Specifying usb port to connected lidar'"},
+                           {'name': 'serial_baudrate',  'default': '115200',           'description':"'Specifying usb port baudrate to connected lidar'"},
+                           {'name': 'frame_id',         'default': 'laser',            'description':"'Specifying frame_id of lidar'"},
+                           {'name': 'inverted',         'default': 'false',            'description':"'Specifying whether or not to invert scan data'"},
+                           {'name': 'angle_compensate', 'default': 'true',             'description':"'Specifying whether or not to enable angle_compensate of scan data'"},
+                           {'name': 'scan_mode',        'default': 'Boost',            'description':"''"}, # Check if this is supported
+                           ]
+
+# lidar supported modes
+# Standard: max_distance: 12.0 m, Point number: 2.0K
+# Express: max_distance: 12.0 m, Point number: 4.0K
+# Boost: max_distance: 12.0 m, Point number: 8.0K
+
+def declare_configurable_parameters(parameters):
+    return [DeclareLaunchArgument(param['name'], default_value=param['default'], description=param['description']) for param in parameters]
+
+def set_configurable_parameters(parameters):
+    return dict([(param['name'], LaunchConfiguration(param['name'])) for param in parameters])
+
+def generate_launch_description():
+    laser_filter_config = os.path.join(
+        get_package_share_directory('stretch_core'),
+        'config',
+        'laser_filter_params.yaml'
+        )
+    
+    lidar_node = Node(
+            package='sllidar_ros2',
+            node_executable='sllidar_node',
+            node_name='sllidar_node',
+            parameters=[set_configurable_parameters(configurable_parameters)],
+            output='screen')
+
+    laser_filters = Node(
+            package='laser_filters',
+            node_executable='scan_to_scan_filter_chain',
+            node_name='laser_filter',
+            parameters=[laser_filter_config]
+            )
+
+    return LaunchDescription(declare_configurable_parameters(configurable_parameters) + [
+        lidar_node,
+        laser_filters,
+    ])

--- a/stretch_core/launch/rplidar.launch.py
+++ b/stretch_core/launch/rplidar.launch.py
@@ -32,7 +32,7 @@ def generate_launch_description():
         'config',
         'laser_filter_params.yaml'
         )
-    
+
     lidar_node = Node(
             package='sllidar_ros2',
             executable='sllidar_node',
@@ -47,28 +47,7 @@ def generate_launch_description():
             parameters=[laser_filter_config]
             )
 
-    # shut_laser = ExecuteProcess(
-    #     cmd=[[
-    #         'hello_robot_lrf_off.py'
-    #     ]],
-    #     shell=True
-    # )
-
-    # laser_shutdown = RegisterEventHandler(
-    # OnShutdown(
-    #     on_shutdown=[
-    #             LogInfo(msg='Lidar was asked to shutdown'),
-    #             ExecuteProcess(
-    #                 cmd=[[
-    #                     'hello_robot_lrf_off.py'
-    #                 ]]
-    #             )
-    #         ]
-    #     )
-    # )   
-
     return LaunchDescription(declare_configurable_parameters(configurable_parameters) + [
         lidar_node,
         laser_filters,
-        # laser_shutdown,
     ])

--- a/stretch_core/launch/rplidar.launch.py
+++ b/stretch_core/launch/rplidar.launch.py
@@ -2,10 +2,10 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import LogInfo
+from launch.actions import DeclareLaunchArgument, LogInfo, ExecuteProcess, RegisterEventHandler
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch.event_handlers import OnShutdown
 
 configurable_parameters = [{'name': 'serial_port',      'default': '/dev/hello-lrf',   'description':"'Specifying usb port to connected lidar'"},
                            {'name': 'serial_baudrate',  'default': '115200',           'description':"'Specifying usb port baudrate to connected lidar'"},
@@ -35,19 +35,40 @@ def generate_launch_description():
     
     lidar_node = Node(
             package='sllidar_ros2',
-            node_executable='sllidar_node',
-            node_name='sllidar_node',
+            executable='sllidar_node',
+            name='sllidar_node',
             parameters=[set_configurable_parameters(configurable_parameters)],
             output='screen')
 
     laser_filters = Node(
             package='laser_filters',
-            node_executable='scan_to_scan_filter_chain',
-            node_name='laser_filter',
+            executable='scan_to_scan_filter_chain',
+            name='laser_filter',
             parameters=[laser_filter_config]
             )
+
+    # shut_laser = ExecuteProcess(
+    #     cmd=[[
+    #         'hello_robot_lrf_off.py'
+    #     ]],
+    #     shell=True
+    # )
+
+    # laser_shutdown = RegisterEventHandler(
+    # OnShutdown(
+    #     on_shutdown=[
+    #             LogInfo(msg='Lidar was asked to shutdown'),
+    #             ExecuteProcess(
+    #                 cmd=[[
+    #                     'hello_robot_lrf_off.py'
+    #                 ]]
+    #             )
+    #         ]
+    #     )
+    # )   
 
     return LaunchDescription(declare_configurable_parameters(configurable_parameters) + [
         lidar_node,
         laser_filters,
+        # laser_shutdown,
     ])


### PR DESCRIPTION
Ported launch file that triggers the sllidar node from the sllidar_ros2 package. This package has not been released officially by Slamtech. I have added it to the installation script so that it's installed with everything else. Known issue: the rplidar motor continues to spin after the node has been killed; requires use of hello_robot_lrf_off.py to stop the motor.