### PR TITLE
Bugfix for Dxl joints not moving in MoveIt 2

### DIFF
--- a/stretch_core/stretch_core/joint_trajectory_server.py
+++ b/stretch_core/stretch_core/joint_trajectory_server.py
@@ -59,6 +59,7 @@ class JointTrajectoryAction(Node):
         n_points = max([len(trajectory.points) for trajectory in trajectories])
         duration = max([Duration.from_msg(trajectory.points[-1].time_from_start) for trajectory in trajectories])
         self.node.get_logger().info(f"{self.node.node_name} joint_traj action: new traj with {n_points} points over {to_sec(duration.to_msg())} seconds")
+        self.node.robot.stop_trajectory()
         for joint in self.joints:
             self.joints[joint].trajectory_manager.trajectory.clear()
         for trajectory in trajectories:
@@ -67,7 +68,6 @@ class JointTrajectoryAction(Node):
                     self.joints[joint_name].add_waypoints(trajectory.points, joint_index)
                 except KeyError as e:
                     return self.error_callback(goal_handle, FollowJointTrajectory.Result.INVALID_GOAL, str(e))
-        self.node.robot.stop_trajectory()
         if not self.node.robot.follow_trajectory():
             self.node.robot.stop_trajectory()
             return self.error_callback(goal_handle, -100, 'hardware failed to start trajectory')


### PR DESCRIPTION
This was a result of the robot.stop_trajectory() method in stretch_body treating Stepper and Dxl joints differently.

For Stepper joints, the method only stops current trajectory execution. For Dxl joints it doesn’t just stop execution but also clears the trajectory and resets the hardware, resulting in an empty trajectory before the follow_trajectory() method is executed.

I am assuming that this method helps with preemption, so just shifting the stop_trajectory() command further up in the execute_callback() allows us to retain functionality while resolving the bug.

This resolves the dysfunctional Dxl joints in MoveIt 2 issue.