### PR TITLE
Allow mapping and navigation to be started without RViz

### DIFF
--- a/stretch_nav2/launch/navigation.launch.py
+++ b/stretch_nav2/launch/navigation.launch.py
@@ -2,6 +2,7 @@ import os
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -37,6 +38,8 @@ def generate_launch_description():
         default_value=os.path.join(stretch_navigation_path, 'config', 'nav2_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
+    rviz_param = DeclareLaunchArgument('use_rviz', default_value='true', choices=['true', 'false'])
+
     stretch_driver_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, '/launch/stretch_driver.launch.py']),
         launch_arguments={'mode': 'navigation', 'broadcast_odom_tf': 'True'}.items())
@@ -53,10 +56,12 @@ def generate_launch_description():
         launch_arguments={'use_sim_time': LaunchConfiguration('use_sim_time'), 
                           'autostart': LaunchConfiguration('autostart'),
                           'map': LaunchConfiguration('map'),
-                          'params_file': LaunchConfiguration('params_file')}.items())
+                          'params_file': LaunchConfiguration('params_file'),
+                          'use_rviz': LaunchConfiguration('use_rviz')}.items())
 
     rviz_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([navigation_bringup_path, '/launch/rviz_launch.py']))
+        PythonLaunchDescriptionSource([navigation_bringup_path, '/launch/rviz_launch.py']),
+        condition=IfCondition(LaunchConfiguration('use_rviz')))
 
     return LaunchDescription([
         teleop_type_param,
@@ -64,6 +69,7 @@ def generate_launch_description():
         autostart_param,
         map_path_param,
         params_file_param,
+        rviz_param,
         stretch_driver_launch,
         rplidar_launch,
         base_teleop_launch,

--- a/stretch_nav2/launch/offline_mapping.launch.py
+++ b/stretch_nav2/launch/offline_mapping.launch.py
@@ -2,6 +2,7 @@ import os
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -11,6 +12,8 @@ from ament_index_python.packages import get_package_share_directory
 def generate_launch_description():
     stretch_core_path = get_package_share_directory('stretch_core')
     stretch_navigation_path = get_package_share_directory('stretch_nav2')
+    
+    rviz_param = DeclareLaunchArgument('use_rviz', default_value='true', choices=['true', 'false'])
     
     teleop_type = DeclareLaunchArgument(
         'teleop_type', default_value="joystick", description="how to teleop ('keyboard', 'joystick' or 'none')")
@@ -41,9 +44,11 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([get_package_share_directory('slam_toolbox'), '/launch/offline_launch.py']))
 
     rviz_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([get_package_share_directory('nav2_bringup'), '/launch/rviz_launch.py']))    
+        PythonLaunchDescriptionSource([get_package_share_directory('nav2_bringup'), '/launch/rviz_launch.py']),
+        condition=IfCondition(LaunchConfiguration('use_rviz')))    
 
     return LaunchDescription([
+        rviz_param,
         teleop_type,
         declare_use_sim_time_argument,
         declare_slam_params_file_cmd,


### PR DESCRIPTION
Sometimes it comes in handy to start mapping and navigation from another computer (without a VNC), launching everything but RViz on the Stretch and only running RViz on your local machine. The following simple changes to the two launch files allow the user to specify this behavior with an additional flag `use_rviz`, which is set to `true` by default.