### PR TITLE
Fix for executing keyboard teleop node from launch file

### DIFF
--- a/stretch_core/launch/keyboard_teleop.launch.py
+++ b/stretch_core/launch/keyboard_teleop.launch.py
@@ -16,7 +16,8 @@ def generate_launch_description():
     keyboard_teleop = Node(
             package='stretch_core',
             executable='keyboard_teleop',
-            output='screen'
+            output='screen',
+            prefix='xterm -e'
             )
 
     return LaunchDescription([

--- a/stretch_core/launch/keyboard_teleop.launch.py
+++ b/stretch_core/launch/keyboard_teleop.launch.py
@@ -10,7 +10,7 @@ def generate_launch_description():
 
     stretch_driver = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([str(stretch_core_path), '/launch/stretch_driver.launch.py']),
-        launch_arguments={'mode': 'trajectory', 'broadcast_odom_tf': 'True', 'fail_out_of_range_goal': 'False'}.items(),
+        launch_arguments={'mode': 'position', 'broadcast_odom_tf': 'True', 'fail_out_of_range_goal': 'False'}.items(),
     )
 
     keyboard_teleop = Node(

--- a/stretch_core/package.xml
+++ b/stretch_core/package.xml
@@ -42,6 +42,7 @@
   <depend>tf2_ros</depend>
   <depend>laser_filters</depend>
   <depend>rplidar_ros</depend>
+  <depend>xterm</depend>
 
   <exec_depend>diagnostic_aggregator</exec_depend>
   <!-- Temporarily Disabled (see https://github.com/ros-perception/laser_filters/issues/132)


### PR DESCRIPTION
## Summary

Fixes stdin for termios used by the keyboard teleop node. This is done by adding a launch prefix to execute the `keyboard_teleop` node in a new xterm window.

## How to test

Build the colcon workspace and launch keyboard teleop:
```
ros2 launch stretch_core keyboard_teleop.launch.py 
```

You should be able to tele-operate the robot without any stdin issues.