### PR TITLE
Fix for MoveIt 2 API changes

### DIFF
--- a/stretch_moveit2/stretch_moveit_config/src/movegroup_test.cpp
+++ b/stretch_moveit2/stretch_moveit_config/src/movegroup_test.cpp
@@ -538,7 +538,7 @@ int main(int argc, char** argv)
   // Visualize the plan in RViz:
   visual_tools.deleteAllMarkers();
   visual_tools.publishText(text_pose, "Joint_Space_Goal", rvt::WHITE, rvt::XLARGE);
-  visual_tools.publishTrajectoryLine(my_plan.trajectory, ee_parent_link, joint_model_group);
+  visual_tools.publishTrajectoryLine(my_plan.trajectory_, ee_parent_link, joint_model_group);
   visual_tools.trigger();
   visual_tools.prompt("Press 'next' in the RvizVisualToolsGui window to continue the demo");
 

--- a/stretch_moveit2/stretch_moveit_config/src/moveit_draw.cpp
+++ b/stretch_moveit2/stretch_moveit_config/src/moveit_draw.cpp
@@ -140,17 +140,17 @@ int main(int argc, char** argv)
     RCLCPP_INFO(LOGGER, "Visualizing plan (joint space goal) %s", success ? "" : "FAILED");
 
     if(i <= 1){
-      disp_plan.trajectory = my_plan.trajectory;
+      disp_plan.trajectory_ = my_plan.trajectory_;
     }
     else{
       std::vector<trajectory_msgs::msg::JointTrajectoryPoint> a, b;
-      a = disp_plan.trajectory.joint_trajectory.points;
-      b = my_plan.trajectory.joint_trajectory.points;
+      a = disp_plan.trajectory_.joint_trajectory.points;
+      b = my_plan.trajectory_.joint_trajectory.points;
       a.insert(std::end(a), std::begin(b), std::end(b));
-      disp_plan.trajectory.joint_trajectory.points = a;
+      disp_plan.trajectory_.joint_trajectory.points = a;
 
       visual_tools.deleteAllMarkers();
-      visual_tools.publishTrajectoryLine(disp_plan.trajectory, ee_parent_link, joint_model_group);
+      visual_tools.publishTrajectoryLine(disp_plan.trajectory_, ee_parent_link, joint_model_group);
       visual_tools.trigger();
     }
 


### PR DESCRIPTION
## Summary

Latest MoveIt API has changed the trajectory attribute of `moveit::planning_interface::MoveGroupInterface::Plan` struct. Source code for Humble and newer can be found [here](https://github.com/ros-planning/moveit2/blob/8d7a2140eab5d7ab344ab82f232e1e842fe21432/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h#L118)

## How to test

Build the colcon workspace and there should be no compiler build errors