### PR TITLE
Bugfix/time string manipulation

### DIFF
--- a/stretch_calibration/README.md
+++ b/stretch_calibration/README.md
@@ -101,6 +101,12 @@ In the images below, examples of good and bad fit between the point cloud and th
 1. Start using the newest head calibration
 
    `ros2 run stretch_calibration update_with_most_recent_calibration`
+
+1. Build the workspace and source environment variables
+
+   `cd ~/ament_ws`
+   `colcon build`
+   `source install/setup.bash`
    
 1. Test the current head calibration
 
@@ -127,6 +133,12 @@ When a new calibration is performed, it is timestamped and added to the calibrat
 1. Revert to the previous head calibration
 
    `ros2 run stretch_calibration revert_to_previous_calibration`
+
+1. Build the workspace and source environment variables
+
+   `cd ~/ament_ws`
+   `colcon build`
+   `source install/setup.bash`
 
 ## License
 

--- a/stretch_calibration/README.md
+++ b/stretch_calibration/README.md
@@ -105,7 +105,9 @@ In the images below, examples of good and bad fit between the point cloud and th
 1. Build the workspace and source environment variables
 
    `cd ~/ament_ws`
+   
    `colcon build`
+   
    `source install/setup.bash`
    
 1. Test the current head calibration
@@ -137,7 +139,9 @@ When a new calibration is performed, it is timestamped and added to the calibrat
 1. Build the workspace and source environment variables
 
    `cd ~/ament_ws`
+   
    `colcon build`
+   
    `source install/setup.bash`
 
 ## License

--- a/stretch_calibration/stretch_calibration/revert_to_previous_calibration.py
+++ b/stretch_calibration/stretch_calibration/revert_to_previous_calibration.py
@@ -13,6 +13,15 @@ def run_cmd(cmdstr):
         sys.exit(1)
     return process
 
+def get_create_time_from_path(file):
+    time_format = 'yyyymmddhhmmss'
+    len_time_format = len(time_format)
+
+    len_file_type = len(os.path.splitext(file)[1])
+    len_filepath = len(file)
+
+    return float(file[(len_filepath-len_file_type-len_time_format):(len_filepath-len_file_type)])
+
 def main():
     print("Attempt to revert to the previous calibration")
 
@@ -30,7 +39,7 @@ def main():
     folder_path = "{0}/{1}/calibration_ros".format(os.getenv('HELLO_FLEET_PATH'), os.getenv('HELLO_FLEET_ID'))
     file_type = '/head_calibration_result_*.yaml'
     files = glob.glob(folder_path + file_type)
-    optimization_file = max(files, key=os.path.getctime)
+    optimization_file = max(files, key=get_create_time_from_path)
 
     print("Path to the most recent optimization results file is: ", optimization_file)
     print("Moving the optimization file to the reversion directory")
@@ -44,7 +53,7 @@ def main():
 
     file_type = '/controller_calibration_head_*.yaml'
     files = glob.glob(folder_path + file_type)
-    controller_file = max(files, key=os.path.getctime)
+    controller_file = max(files, key=get_create_time_from_path)
 
     print("Path to the most recent controller calibration file is: ", controller_file)
     print("Moving the controller calibration file to the reversion directory")
@@ -58,7 +67,7 @@ def main():
 
     file_type = '/head_calibrated*.urdf'
     files = glob.glob(folder_path + file_type)
-    urdf_file = max(files, key=os.path.getctime)
+    urdf_file = max(files, key=get_create_time_from_path)
 
     print("Path to the most recent calibrated URDF file is: ", urdf_file)
     print("Moving the calibrated urdf file to the reversion directory")

--- a/stretch_calibration/stretch_calibration/visualize_most_recent_head_calibration.py
+++ b/stretch_calibration/stretch_calibration/visualize_most_recent_head_calibration.py
@@ -5,6 +5,14 @@ import os
 import glob
 import sys
 
+def get_create_time_from_path(file):
+    time_format = 'yyyymmddhhmmss'
+    len_time_format = len(time_format)
+
+    len_file_type = len(os.path.splitext(file)[1])
+    len_filepath = len(file)
+
+    return float(file[(len_filepath-len_file_type-len_time_format):(len_filepath-len_file_type)])
 
 def main():
     folder_path = "{0}/{1}/calibration_ros".format(os.getenv('HELLO_FLEET_PATH'), os.getenv('HELLO_FLEET_ID'))
@@ -15,7 +23,7 @@ def main():
 
     file_type = '/head_calibration_result_*.yaml'
     files = glob.glob(folder_path + file_type)
-    optimization_file = max(files, key=os.path.getctime)
+    optimization_file = max(files, key=get_create_time_from_path)
 
     print("Path to the most recent optimization results file is: ", optimization_file)
 
@@ -25,7 +33,7 @@ def main():
 
     file_type = '/controller_calibration_head_*.yaml'
     files = glob.glob(folder_path + file_type)
-    controller_file = max(files, key=os.path.getctime)
+    controller_file = max(files, key=get_create_time_from_path)
 
     print("Path to the most recent controller calibration file is: ", controller_file)
 
@@ -35,7 +43,7 @@ def main():
 
     file_type = '/head_calibrated*.urdf'
     files = glob.glob(folder_path + file_type)
-    urdf_file = max(files, key=os.path.getctime)
+    urdf_file = max(files, key=get_create_time_from_path)
 
     print("Path to the most recent calibrated URDF file is: ", urdf_file)
 


### PR DESCRIPTION
This PR adds the time string manipulation fix to the following scripts:
1. Visualize most recent head calibration
2. Revert to previous calibration

It also adds a build step in the README after updating the calibration files in the src path of the workspace.