### PR TITLE
Add stow service to Humble

### DIFF
--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -473,6 +473,15 @@ class StretchDriver(Node):
         response.message = 'Homed.'
         return response
 
+    def stow_the_robot_callback(self, request, response):
+        with self.robot_stop_lock:
+            self.robot.stow()
+
+        self.get_logger().info('Received stow_the_robot service call.')
+        response.success = True
+        response.message = 'Stowed.'
+        return response
+
     def navigation_mode_service_callback(self, request, response):
         success, message = self.turn_on_navigation_mode()
         response.success = success
@@ -666,6 +675,10 @@ class StretchDriver(Node):
         self.home_the_robot_service = self.create_service(Trigger,
                                                           '/home_the_robot',
                                                           self.home_the_robot_callback)
+
+        self.stow_the_robot_service = self.create_service(Trigger,
+                                                           '/stow_the_robot',
+                                                           self.stow_the_robot_callback)
 
         self.runstop_service = self.create_service(SetBool,
                                                    '/runstop',


### PR DESCRIPTION
## Summary

This feature adds a stowing service to `stretch_driver`. It utilizes the `robot.stow()` method provided by Stretch Body.

## How-to-test
In a terminal, run
```
ros2 launch stretch_core stretch_driver.launch.py
```
In a separate terminal, run
```
ros2 service call /stow_the_robot std_srvs/srv/Trigger
```