### PR TITLE
 ROS 2: Mode services in stretch_driver improvements + bugfixes

### DIFF
--- a/stretch_core/README.md
+++ b/stretch_core/README.md
@@ -24,6 +24,95 @@ Config:
  - `laser_filter_params.yaml`: configures the filters that are used for laser scan filtering
  - `stretch_marker_dict.yaml`: stores information about ArUco markers known and assigned for use with Stretch
 
+## API
+
+### Nodes
+
+### [stretch_driver](./stretch_core/stretch_driver.py)
+
+#### Parameters
+
+##### broadcast_odom_tf
+
+If set to true, stretch_driver will publish an odom to base_link TF.
+
+##### fail_out_of_range_goal
+
+If set to true, motion action servers will fail on out-of-range commands.
+
+##### mode
+
+Can be set to `position`, `navigation`, and `trajectory` modes.
+
+##### calibrated_controller_yaml_file
+
+Path to the calibrated controller args file
+
+#### Published Topics
+
+##### /mode ([std_msgs/String](https://docs.ros2.org/latest/api/std_msgs/msg/String.html))
+
+This topic publishes which mode the driver is in at 15hz. stretch_driver has a few modes that change how the robot is controlled. The modes are:
+
+  - "position": The default and simplest mode. In this mode, you can control every joint on the robot using position commands. For example, the telescoping arm (whose range is from zero fully retracted to ~52 centimeters fully extended) would move to 25cm out when you send it a 0.25m position cmd <!-- [0.25m position cmd](../hello_helpers/README.md#movetoposepose-returnbeforedonefalse-customcontactthresholdsfalse-customfullgoalfalse)-->. Two kinds of position commands are available for the mobile base, translation and rotation, with joint names "translate_mobile_base" and "rotate_mobile_base", and these commands have no limits since the wheels can spin continuously.
+   - Position commands are tracked in the firmware by a trapezoidal motion profile, and specifing the optional velocity and acceleration in [JointTrajectoryPoint](https://docs.ros2.org/latest/api/trajectory_msgs/msg/JointTrajectoryPoint.html) changes the shape of the trapezoid. <!-- More details about the motion profile [in the tutorial](https://docs.hello-robot.com/0.2/stretch-tutorials/ros1/follow_joint_trajectory/). -->
+   - Position commands can be contact sensitive, which is helpful for manipulating objects in the world. For example, I could [open a cabinet](https://youtu.be/SXgj9be3PdM) by reaching out with the telescoping arm and detecting contact with the door. In order to specify contact thresholds for a position command, the optional effort in [JointTrajectoryPoint](https://docs.ros2.org/latest/api/trajectory_msgs/msg/JointTrajectoryPoint.html) is misused to mean a threshold for the effort the robot will apply while executing the position command.
+   - Position commands can be preemptable, so you can issue a new position command before the previous one has finished and the robot will smoothly move to execute the latest command. This feature is helpful for scripts that use visual servo-ing or allow a user to teleop the robot.
+   - The driver can be switched into "position" mode at any time using the [switch_to_position_mode service](#TODO).
+ - "navigation": In this mode, every joint behaves identically to "position" mode except for the mobile base. The mobile base responds to velocity commands at a topic instead of position commands via the "translate_mobile_base" and "rotate_mobile_base" joints in the action server. You would publish [geometry_msgs/Twist](https://docs.ros2.org/latest/api/geometry_msgs/msg/Twist.html) messages to the [/stretch/cmd_vel topic](#TODO). Since Twist messages are generalized to robots that can move with velocity in any direction, only the `Twist.linear.x` (translational velocity) and `Twist.angular.z` (rotational velocity) fields apply for differential drive mobile bases.
+   - Velocity control of the base is a common way to move mobile robots around. For example, the [Navigation Stack](../stretch_nav2/README.md) is a piece of software that uses this mode to move the robot to different points in a map.
+   - This mode has a few safety features to prevent Stretch from "running away" at the last commanded velocity if the node that was sending commands were to crash for whatever reason. The first is a 0.5 second timeout within the stretch_driver node, which means that if the driver doesn't receive a new Twist command within 0.5s, the base will be commanded to stop smoothly. The second is a 1 second timeout within the firmware of the wheels, which means that even if the ROS layer were to crash, the robot will still be commanded to stop abruptly within 1 second at the lowest layer. This low-level feature was added relatively recently to the firmware, so be sure to [update your firmware](https://github.com/hello-robot/stretch_firmware/blob/master/docs/tutorial_updating_firmware.md) to the latest version.
+   - The driver can be switched into "navigation" mode at any time using the [switch_to_navigation_mode service](#TODO).
+ - "trajectory": In this mode, every joint follows a trajectory that is modeled as a spline. The key benefit of this mode is control over the timing at which the robot achieves positions (a.k.a waypoints), enabling smooth and coordinated motion through a preplanned trajectory. [More details here](https://forum.hello-robot.com/t/creating-smooth-motion-using-trajectories/671).
+ - "homing": This is the mode reported by the driver when a homing sequence has been triggered (e.g. through the [home_the_robot service](#hometherobot-stdsrvstriggerhttpsdocsrosorgennoeticapistdsrvshtmlsrvtriggerhtml)). While this mode is active, no other commands will be accepted by the driver. After the robot has completed its 30 second homing sequence, it will return to the mode it was in before.
+ - "stowing": This is the mode reported by the driver when a stowing sequence has been triggered (e.g. through the [stow_the_robot service](#stowtherobot-stdsrvstriggerhttpsdocsrosorgennoeticapistdsrvshtmlsrvtriggerhtml)). While this mode is active, no other commands will be accepted by the driver. After the robot has completed its stowing sequence, it will return to the mode it was in before.
+ - "runstopped": This is the mode reported by the driver when the robot is in runstop, either through the user pressing the [glowing white button](https://docs.hello-robot.com/0.2/stretch-tutorials/getting_started/safety_guide/#runstop) in Stretch's head or through the [runstop service](#runstop-stdsrvssetboolhttpsdocsrosorgennoeticapistdsrvshtmlsrvsetboolhtml). While this mode is active, no other commands will be accepted by the driver. After the robot has been taken out of runstop, it will return to the mode it was in before, or "position" mode if the driver was launched while the robot was runstopped.
+ <!-- - "manipulation": **Deprecated**. This mode was previously available in ROS1 Melodic, but was removed when the driver was ported to ROS1 Noetic. The mode supported a virtual prismatic joint for the mobile base, allowing you to treat the mobile base as a joint that could move forwards/backwards 0.5m. It was removed because the mode had little utility for most users of the driver. -->
+
+##### /battery ([sensor_msgs/BatteryState](https://docs.ros2.org/latest/api/sensor_msgs/msg/BatteryState.html))
+
+This topic publishes Stretch's battery and charge status. Charging status, the `power_supply_status` field, is estimated by looking at changes in voltage readings over time, where plugging-in causes the voltage to jump up (i.e. status becomes 'charging') and pulling the plug out is detected by a voltage dip (i.e. status becomes 'discharging'). Estimation of charging status is most reliable when the charger is in SUPPLY mode (see [docs here](https://docs.hello-robot.com/0.2/stretch-hardware-guides/docs/battery_maintenance_guide_re1/#charger) for how to change charging modes). Charging status is unknown at boot of this node. Consequently, the `current` field is positive at boot of this node, regardless of whether the robot is charging/discharging. After a charging state change, there is a ~10 second timeout where state changes won't be detected. Additionally, outlier voltage readings can slip past the filters and incorrectly indicate a charging state change (albeit rarely). Finally, voltage readings are affected by power draw (e.g. the onboard computer starts a computationally taxing program), which can lead to incorrect indications of charging state change. Stretch RE2s have a hardware switch in the charging port that can detect when a plug has been plugged in, regardless of whether the plug is providing any power. Therefore, this node combines the previous voltage-based estimate with readings from this hardware switch to make better charging state estimates on RE2s (effectively eliminating the false positive case where a computational load draws more power).
+
+Since a battery is always present on a Stretch system, we instead misuse the `present` field to indicate whether a plug is plugged in to the charging port (regardless of whether it's providing power) on RE2 robots. This field is always false on RE1s. The unmeasured fields (e.g. charge in Ah) return a NaN, or 'not a number'.
+
+##### /is_homed ([std_msgs/Bool](https://docs.ros2.org/latest/api/std_msgs/msg/Bool.html))
+
+This topic publishes whether Stretch's encoders has been homed. If the robot isn't homed, joint states will be incorrect and motion commands won't be accepted by the driver. The [home_the_robot service](#hometherobot-stdsrvstriggerhttpsdocsrosorgennoeticapistdsrvshtmlsrvtriggerhtml) can be used to home Stretch.
+
+##### /is_runstopped ([std_msgs/Bool](https://docs.ros2.org/latest/api/std_msgs/msg/Bool.html))
+
+This topic publishes whether Stretch is runstopped. When the robot is runstopped (typically by [pressing glowing white button](https://docs.hello-robot.com/0.2/stretch-tutorials/getting_started/safety_guide/#runstop) in Stretch's head), motion for all joints is stopped and new motion commands aren't accepted. This is a safety feature built into the firmware for the four primary actuators. It's also possible to runstop the robot programmatically using the [runstop service](#runstop-stdsrvssetboolhttpsdocsrosorgennoeticapistdsrvshtmlsrvsetboolhtml)
+
+<!-- ##### /is_calibrated ([std_msgs/Bool](https://docs.ros2.org/latest/api/std_msgs/msg/Bool.html))
+
+**Deprecated:** This topic has been renamed to [is_homed](#ishomed-stdmsgsboolhttpsdocsrosorgennoeticapistdmsgshtmlmsgboolhtml) because we often use the terms "calibrated" or "calibration" in context of [URDF calibrations](../stretch_calibration/README.md), whereas this topic returns whether the robot's encoders are homed. -->
+
+#### Published Services
+
+##### /home_the_robot ([std_srvs/Trigger](https://docs.ros2.org/latest/api/std_srvs/srv/Trigger.html))
+
+This service will start Stretch's homing procedure, where every joint's zero is found. Robots with relative encoders (vs absolute encoders) need a homing procedure when they power on. For Stretch, it's a 30-second procedure that must occur everytime the robot wakes up before you may send motion commands to or read correct joint positions from Stretch's prismatic and multiturn revolute joints. When this service is triggered, the [mode topic](https://docs.ros2.org/latest/api/std_msgs/msg/String.html) will reflect that the robot is in "homing" mode, and after the homing procedure is complete, will switch back to whatever mode the robot was in before this service was triggered. While stretch_driver is in "homing" mode, no commands to the [cmd_vel topic](#TODO) or the [follow joint trajectory action service](#TODO) will be accepted.
+
+Other ways to home the robot include using the `stretch_robot_home.py` CLI tool from a terminal, or calling [`robot.home()`](https://docs.hello-robot.com/0.2/stretch-tutorials/stretch_body/tutorial_stretch_body_api/#stretch_body.robot.Robot.home) from Stretch's Python API.
+
+Runstopping the robot while this service is running will yield undefined behavior and likely leave the driver in a bad state.
+
+##### /stow_the_robot ([std_srvs/Trigger](https://docs.ros2.org/latest/api/std_srvs/srv/Trigger.html))
+
+This service will start Stretch's stowing procedure, where the arm is stowed into the footprint of the mobile base. This service is more convenient than sending a [follow joint trajectory command](#TODO) since it knows what gripper is installed at the end of arm and stows these additional joints automatically. When this service is triggered, the [mode topic](#mode-stdmsgsstringhttpsdocsrosorgennoeticapistdmsgshtmlmsgstringhtml) will reflect that the robot is in "stowing" mode, and after the homing procedure is complete, will switch back to whatever mode the robot was in before this service was triggered. While stretch_driver is in "stowing" mode, no commands to the [cmd_vel topic](#TODO) or the [follow joint trajectory action service](#TODO) will be accepted.
+
+Other ways to stow the robot include using the `stretch_robot_stow.py` CLI tool from a terminal, or calling [`robot.stow()`](https://docs.hello-robot.com/0.2/stretch-tutorials/stretch_body/tutorial_stretch_body_api/#stretch_body.robot.Robot.stow) from Stretch's Python API.
+
+Runstopping the robot while this service is running will yield undefined behavior and likely leave the driver in a bad state.
+
+##### /runstop ([std_srvs/SetBool](https://docs.ros2.org/latest/api/std_srvs/srv/SetBool.html))
+
+This service can put Stretch into runstop or take Stretch out of runstop. It's common to put the robot into/out of runstop by pressing the [glowing white button](https://docs.hello-robot.com/0.2/stretch-tutorials/getting_started/safety_guide/#runstop) in Stretch's head (at which point the robot will beep and the button will be blinking to indicate that it's runstopped), and holding the button down for two seconds to take it out of runstop (the button will return to non-blinking). This service acts as a programmatic way to achieve the same effect. When this service is triggered, the [mode topic](#mode-stdmsgsstringhttpsdocsrosorgennoeticapistdmsgshtmlmsgstringhtml) will reflect that the robot is in "runstopped" mode, and after the robot is taken out of runstop, the driver will switch back to whatever mode the robot was in before this service was triggered. While stretch_driver is in "runstopped" mode, no commands to the [cmd_vel topic](#TODO) or the [follow joint trajectory action service](#TODO) will be accepted.
+
+<!-- ##### /calibrate_the_robot ([std_srvs/Trigger](https://docs.ros2.org/latest/api/std_srvs/srv/Trigger.html))
+
+**Deprecated:** This service has been renamed to [home_the_robot](https://docs.ros2.org/latest/api/std_srvs/srv/Trigger.html) because we often use the terms "calibrate" or "calibration" in context of [URDF calibrations](../stretch_calibration/README.md), whereas this service homes the robot's encoders. -->
+
 ## Testing
 
 Colcon is used to run the integration tests in the */test* folder. The command to run the entire suite of tests is:

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -67,7 +67,7 @@ class StretchDriver(Node):
         self.robot_mode_rwlock = RWLock()
         self.robot_mode = None
 
-        self.control_modes = ['position', 'navigation']
+        self.control_modes = ['position', 'navigation', 'trajectory']
         self.prev_runstop_state = None
 
         self.ros_setup()

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import copy
 import yaml
 import numpy as np
 import threading
@@ -65,6 +66,9 @@ class StretchDriver(Node):
 
         self.robot_mode_rwlock = RWLock()
         self.robot_mode = None
+
+        self.control_modes = ['position', 'navigation']
+        self.prev_runstop_state = None
 
         self.ros_setup()
 
@@ -266,6 +270,11 @@ class StretchDriver(Node):
         homed_status.data = bool(self.robot.is_calibrated())
         self.homed_pub.publish(homed_status)
 
+        # publish runstop event
+        runstop_event = Bool()
+        runstop_event.data = robot_status['pimu']['runstop_event']
+        self.runstop_event_pub.publish(runstop_event)
+
         mode_msg = String()
         mode_msg.data = self.robot_mode
         self.mode_pub.publish(mode_msg)
@@ -390,15 +399,22 @@ class StretchDriver(Node):
 
         self.robot_mode_rwlock.release_read()
 
+        # must happen after the read release, otherwise the write lock in change_mode() will cause a deadlock
+        if (self.prev_runstop_state == None and runstop_event.data) or (self.prev_runstop_state != None and runstop_event.data != self.prev_runstop_state):
+            self.runstop_the_robot(runstop_event.data, just_change_mode=True)
+        self.prev_runstop_state = runstop_event.data
+
     # CHANGE MODES ################
 
-    def change_mode(self, new_mode, code_to_run):
+    def change_mode(self, new_mode, code_to_run = None):
         self.robot_mode_rwlock.acquire_write()
         self.robot_mode = new_mode
-        success, message = code_to_run()
+        
+        if code_to_run:
+            code_to_run()
+
         self.get_logger().info('{0}: Changed to mode = {1}'.format(self.node_name, self.robot_mode))
         self.robot_mode_rwlock.release_write()
-        return success, message
 
     # TODO : add a freewheel mode or something comparable for the mobile base?
 
@@ -409,8 +425,8 @@ class StretchDriver(Node):
         def code_to_run():
             self.linear_velocity_mps = 0.0
             self.angular_velocity_radps = 0.0
-            return True, 'Now in navigation mode.'
-        return self.change_mode('navigation', code_to_run)
+        self.change_mode('navigation', code_to_run)
+        return True, 'Now in navigation mode.'
 
     def turn_on_position_mode(self):
         # Position mode enables mobile base translation and rotation
@@ -421,8 +437,8 @@ class StretchDriver(Node):
         # 'base_link' become identical in this mode.
         def code_to_run():
             self.robot.base.enable_pos_incr_mode()
-            return True, 'Now in position mode.'
-        return self.change_mode('position', code_to_run)
+        self.change_mode('position', code_to_run)
+        return True, 'Now in position mode.'
 
     def turn_on_trajectory_mode(self):
         # Trajectory mode is able to execute plans from
@@ -440,8 +456,9 @@ class StretchDriver(Node):
                 return False, str(e)
             self.robot.base.first_step = True
             self.robot.base.pull_status()
-            return True, 'Now in trajectory mode.'
-        return self.change_mode('trajectory', code_to_run)
+
+        self.change_mode('trajectory', code_to_run)
+        return True, 'Now in trajectory mode.'
 
     # SERVICE CALLBACKS ##############
 
@@ -465,12 +482,11 @@ class StretchDriver(Node):
         return response
 
     def home_the_robot_callback(self, request, response):
-        with self.robot_stop_lock:
-            self.robot.home()
+        success, message = self.home_the_robot()
 
         self.get_logger().info('Received home_the_robot service call.')
-        response.success = True
-        response.message = 'Homed.'
+        response.success = success
+        response.message = message
         return response
 
     def stow_the_robot_callback(self, request, response):
@@ -501,27 +517,49 @@ class StretchDriver(Node):
         return response
 
     def runstop_service_callback(self, request, response):
-        if request.data:
-            with self.robot_stop_lock:
-                self.robot.base.translate_by(0.0)
-                self.robot.base.rotate_by(0.0)
-                self.robot.arm.move_by(0.0)
-                self.robot.lift.move_by(0.0)
-                self.robot.push_command()
-
-                self.robot.head.move_by('head_pan', 0.0)
-                self.robot.head.move_by('head_tilt', 0.0)
-                self.robot.end_of_arm.move_by('wrist_yaw', 0.0)
-                self.robot.end_of_arm.move_by('stretch_gripper', 0.0)
-                self.robot.push_command()
-
-            self.robot.pimu.runstop_event_trigger()
-        else:
-            self.robot.pimu.runstop_event_reset()
+        self.runstop_the_robot(request.data)
 
         response.success = True
         response.message = 'is_runstopped: {0}'.format(request.data)
         return response
+    
+    def home_the_robot(self):
+        self.robot_mode_rwlock.acquire_read()
+        can_home = self.robot_mode in self.control_modes
+        last_robot_mode = copy.copy(self.robot_mode)
+        self.robot_mode_rwlock.release_read()
+        if not can_home:
+            errmsg = f'Cannot home while in mode={last_robot_mode}.'
+            self.get_logger().error(errmsg)
+            return False, errmsg
+        def code_to_run():
+            pass
+        self.change_mode('homing', code_to_run)
+        self.robot.home()
+        self.change_mode(last_robot_mode, code_to_run)
+        return True, 'Homed.'
+
+    def runstop_the_robot(self, runstopped, just_change_mode=False):
+        if runstopped:
+            self.robot_mode_rwlock.acquire_read()
+            already_runstopped = self.robot_mode == 'runstopped'
+            if not already_runstopped:
+                self.prerunstop_mode = copy.copy(self.robot_mode)
+            self.robot_mode_rwlock.release_read()
+            if already_runstopped:
+                return
+            self.change_mode('runstopped', code_to_run=None)
+            if not just_change_mode:
+                self.robot.pimu.runstop_event_trigger()
+        else:
+            self.robot_mode_rwlock.acquire_read()
+            already_not_runstopped = self.robot_mode != 'runstopped'
+            self.robot_mode_rwlock.release_read()
+            if already_not_runstopped:
+                return
+            self.change_mode(self.prerunstop_mode, code_to_run=None)
+            if not just_change_mode:
+                self.robot.pimu.runstop_event_reset()
 
     # ROS Setup #################
     def ros_setup(self):
@@ -541,6 +579,9 @@ class StretchDriver(Node):
 
         self.declare_parameter('mode', "position")
         mode = self.get_parameter('mode').value
+        if mode not in self.control_modes:
+            self.get_logger().warn(f'{self.node_name} given invalid mode={mode}, using position instead')
+            mode = 'position'
         self.get_logger().info('mode = ' + str(mode))
         if mode == "position":
             self.turn_on_position_mode()
@@ -622,13 +663,14 @@ class StretchDriver(Node):
         self.imu_mobile_base_pub = self.create_publisher(Imu, 'imu_mobile_base', 1)
         self.magnetometer_mobile_base_pub = self.create_publisher(MagneticField, 'magnetometer_mobile_base', 1)
         self.imu_wrist_pub = self.create_publisher(Imu, 'imu_wrist', 1)
+        self.runstop_event_pub = self.create_publisher(Bool, 'is_runstopped', 1)
 
         self.group = MutuallyExclusiveCallbackGroup()
         self.create_subscription(Twist, "cmd_vel", self.set_mobile_base_velocity_callback, 1, callback_group=self.group)
 
         self.declare_parameter('rate', 15.0)
         self.joint_state_rate = self.get_parameter('rate').value
-        self.declare_parameter('timeout', 1.0)
+        self.declare_parameter('timeout', 0.5)
         self.timeout_s = self.get_parameter('timeout').value
         self.timeout = Duration(seconds=self.timeout_s)
         self.get_logger().info("{0} rate = {1} Hz".format(self.node_name, self.joint_state_rate))


### PR DESCRIPTION
## Summary

Ports bugfixes and features from https://github.com/hello-robot/stretch_ros/pull/105 to ROS 2 Humble. Updates documentation to ROS 2 latest release.

To trigger runstop events, I have observed that it is necessary to push all queued-up RPC commands using `robot.push_command()`.

## How-to-test

To test each service between homing, stopping, stowing, and switching between operation modes, use the following command template:

```
ros2 service call <service_name> std_srvs/srv/Trigger
```

To test the runstop service, use the command
```
ros2 service call /runstop std_srvs/srv/SetBool data:\ true # or false
```
