### PR TITLE
Fix stretch driver deadlock while switching from trajectory mode

### DIFF
--- a/stretch_core/stretch_core/joint_trajectory_server.py
+++ b/stretch_core/stretch_core/joint_trajectory_server.py
@@ -288,6 +288,7 @@ class JointTrajectoryAction(Node):
                 # self.action_server_rate.sleep()
 
             time.sleep(0.1)
+            self.node.robot_mode_rwlock.release_read()
             self._update_trajectory_dynamixel()
             self._update_trajectory_non_dynamixel()
             return self.success_callback(goal_handle, 'traj succeeded!')


### PR DESCRIPTION
## Summary 

This PR remove a common deadlock situation within `stretch_driver`. Previously while using `keyboard_teleop`, if we switch from trajectory to position mode, the node would stop accepting any new service/action calls.

## How-to-test

First, launch stretch_driver and keyboard_teleop:
```
ros2 launch stretch_core stretch_driver.launch.py
ros2 run stretch_core keyboard_teleop
```

Then, send a few teleop commands first using position mode and then trajectory mode.
Finally, switch back to position mode:
```
ros2 service call /switch_to_position_mode std_srvs/srv/Trigger
```

You should still be able to teleop the robot.