### PR TITLE
Patch for misaligned point cloud issue with realsense driver

### DIFF
--- a/stretch_calibration/launch/simple_test_head_calibration.launch.py
+++ b/stretch_calibration/launch/simple_test_head_calibration.launch.py
@@ -11,6 +11,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([os.path.join(
             get_package_share_directory('stretch_core'), 'launch'),
             '/d435i_high_resolution.launch.py']),
+        launch_arguments={'align_depth.enable': 'False'}.items()
         )
 
     d435i_configure = Node(

--- a/stretch_calibration/launch/simple_test_head_calibration_low_resolution.launch.py
+++ b/stretch_calibration/launch/simple_test_head_calibration_low_resolution.launch.py
@@ -11,6 +11,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([os.path.join(
             get_package_share_directory('stretch_core'), 'launch'),
             '/d435i_low_resolution.launch.py']),
+        launch_arguments={'align_depth.enable': 'False'}.items()
         )
 
     d435i_configure = Node(

--- a/stretch_core/launch/d435i_high_resolution.launch.py
+++ b/stretch_core/launch/d435i_high_resolution.launch.py
@@ -7,6 +7,7 @@ from launch.conditions import LaunchConfigurationEquals
 
 configurable_parameters = [{'name': 'depth_module.profile',         'default': '1280x720x15', 'description': 'depth module profile'},                           
                            {'name': 'rgb_camera.profile',           'default': '1280x720x15', 'description': 'color image width'},
+                           {'name': 'align_depth.enable',           'default': 'true',        'description': 'whether to publish aligned_depth_to_color feed'},
                            ]
                            
 def declare_configurable_parameters(parameters):

--- a/stretch_core/launch/d435i_low_resolution.launch.py
+++ b/stretch_core/launch/d435i_low_resolution.launch.py
@@ -7,6 +7,7 @@ from launch.conditions import LaunchConfigurationEquals
 
 configurable_parameters = [{'name': 'depth_module.profile',         'default': '424x240x15', 'description': 'depth module profile'},                           
                            {'name': 'rgb_camera.profile',           'default': '424x240x15', 'description': 'color image width'},
+                           {'name': 'align_depth.enable',           'default': 'true',       'description': 'whether to publish aligned_depth_to_color feed'},
                            ]
                            
 def declare_configurable_parameters(parameters):


### PR DESCRIPTION
This PR provides a patch for issue [#2595](https://github.com/IntelRealSense/realsense-ros/issues/2595) in the realsense-ros driver. It disables align_depth parameter while visualizing calibration fit but keeps it enabled otherwise.