### PR TITLE
Realsense octomap in Moveit

### DIFF
--- a/stretch_moveit2/config/sensors_3d.yaml
+++ b/stretch_moveit2/config/sensors_3d.yaml
@@ -1,4 +1,3 @@
-# The name of this file shouldn't be changed, or else the Setup Assistant won't detect it
 /**:
     ros__parameters:
         sensors:
@@ -12,4 +11,5 @@
             point_cloud_topic: /camera/depth/color/points
             point_subsample: 1
             sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
-        octomap_resolution: 0.1
+        octomap_resolution: 0.05
+


### PR DESCRIPTION
The following minor changes make Moveit update the **octomap** from the **point cloud** published by the Realsense camera inside the head of the robot by default, see screenshot below:

![moveit-octomap](https://github.com/hello-robot/stretch_ros2/assets/53856473/46eaa1ab-1661-4032-92ee-d15a53ede6d4)

For me for some reason this would not work with Moveit2 installed from Debian packages (`2.3.4-1focal.20221208.*`) while after compiling the Moveit2 `galactic` branch from source [commit 1255936](https://github.com/ros-planning/moveit2/tree/1255936a99a4e5c8625c4d6c2a4171cc5baa271a) it would work without any issues.