### PR TITLE
Move to 30Hz Fast driver rates

### DIFF
--- a/stretch_core/launch/stretch_driver.launch.py
+++ b/stretch_core/launch/stretch_driver.launch.py
@@ -41,13 +41,13 @@ def generate_launch_description():
                                  executable='joint_state_publisher',
                                  output='log',
                                  parameters=[{'source_list': ['/stretch/joint_states']},
-                                             {'rate': 15}])
+                                             {'rate': 30.0}])
 
     robot_state_publisher = Node(package='robot_state_publisher',
                                  executable='robot_state_publisher',
                                  output='both',
                                  parameters=[{'robot_description': robot_description_content},
-                                             {'publish_frequency': 15.0}])
+                                             {'publish_frequency': 30.0}])
 
     aggregator = Node(package='diagnostic_aggregator',
                       executable='aggregator_node',
@@ -55,7 +55,7 @@ def generate_launch_description():
                       parameters=[str(stretch_core_path / 'config/diagnostics.yaml')])
 
     stretch_driver_params = [
-        {'rate': 25.0,
+        {'rate': 30.0,
          'timeout': 0.5,
          'controller_calibration_file': LaunchConfiguration('calibrated_controller_yaml_file'),
          'broadcast_odom_tf': LaunchConfiguration('broadcast_odom_tf'),

--- a/stretch_core/stretch_core/joint_trajectory_server.py
+++ b/stretch_core/stretch_core/joint_trajectory_server.py
@@ -176,7 +176,7 @@ class JointTrajectoryAction(Node):
                 robot_status = self.node.robot.get_status() # uses lock held by robot
                 for c in self.command_groups:
                     c.init_execution(self.node.robot, robot_status)
-                self.node.robot.push_command()
+                # self.node.robot.push_command()
 
                 goals_reached = [c.goal_reached() for c in self.command_groups]
                 goal_start_time = self.node.get_clock().now()

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -706,7 +706,7 @@ class StretchDriver(Node):
         self.group = MutuallyExclusiveCallbackGroup()
         self.create_subscription(Twist, "cmd_vel", self.set_mobile_base_velocity_callback, 1, callback_group=self.group)
 
-        self.declare_parameter('rate', 15.0)
+        self.declare_parameter('rate', 30.0)
         self.joint_state_rate = self.get_parameter('rate').value
         self.declare_parameter('timeout', 0.5)
         self.timeout_s = self.get_parameter('timeout').value

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -70,6 +70,7 @@ class StretchDriver(Node):
 
         self.control_modes = ['position', 'navigation', 'trajectory']
         self.prev_runstop_state = None
+        self.dirty_command = False
 
         self.ros_setup()
 
@@ -408,6 +409,7 @@ class StretchDriver(Node):
         
         self.robot.non_dxl_thread.step()
         self.robot.push_command() # Main push command
+        self.dirty_command = False
 
     # CHANGE MODES ################
 

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -408,8 +408,9 @@ class StretchDriver(Node):
         self.prev_runstop_state = runstop_event.data
         
         self.robot.non_dxl_thread.step()
-        self.robot.push_command() # Main push command
-        self.dirty_command = False
+        if not self.robot_mode == 'trajectory':
+            self.robot.push_command() # Main push command
+            self.dirty_command = False
 
     # CHANGE MODES ################
 

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -99,11 +99,11 @@ class StretchDriver(Node):
             time_since_last_twist = self.get_clock().now() - self.last_twist_time
             if time_since_last_twist < self.timeout:
                 self.robot.base.set_velocity(self.linear_velocity_mps, self.angular_velocity_radps)
-                self.robot.push_command()
+                # self.robot.push_command() #Moved to main
             else:
                 # Too much information in general, although it could be blocked, since it's just INFO.
                 self.robot.base.set_velocity(0.0, 0.0)
-                self.robot.push_command()
+                # self.robot.push_command() #Moved to main
 
         # get copy of the current robot status (uses lock held by the robot)
         robot_status = self.robot.get_status()
@@ -404,6 +404,8 @@ class StretchDriver(Node):
         if (self.prev_runstop_state == None and runstop_event.data) or (self.prev_runstop_state != None and runstop_event.data != self.prev_runstop_state):
             self.runstop_the_robot(runstop_event.data, just_change_mode=True)
         self.prev_runstop_state = runstop_event.data
+        
+        self.robot.push_command() # Main push command
 
     # CHANGE MODES ################
 
@@ -469,13 +471,13 @@ class StretchDriver(Node):
             self.robot.base.rotate_by(0.0)
             self.robot.arm.move_by(0.0)
             self.robot.lift.move_by(0.0)
-            self.robot.push_command()
+            # self.robot.push_command() #Moved to main
 
             self.robot.head.move_by('head_pan', 0.0)
             self.robot.head.move_by('head_tilt', 0.0)
             self.robot.end_of_arm.move_by('wrist_yaw', 0.0)
             self.robot.end_of_arm.move_by('stretch_gripper', 0.0)
-            self.robot.push_command()
+            # self.robot.push_command() #Moved to main
 
         self.get_logger().info('Received stop_the_robot service call, so commanded all actuators to stop.')
         response.success = True
@@ -570,7 +572,7 @@ class StretchDriver(Node):
             self.change_mode('runstopped', code_to_run)
             if not just_change_mode:
                 self.robot.pimu.runstop_event_trigger()
-                self.robot.push_command()
+                # self.robot.push_command()#Moved to main
         else:
             self.robot_mode_rwlock.acquire_read()
             already_not_runstopped = self.robot_mode != 'runstopped'
@@ -583,7 +585,7 @@ class StretchDriver(Node):
             self.change_mode(self.prerunstop_mode, code_to_run)
             if not just_change_mode:
                 self.robot.pimu.runstop_event_reset()
-                self.robot.push_command()
+                # self.robot.push_command() #Moved to main
 
     # ROS Setup #################
     def ros_setup(self):
@@ -717,7 +719,7 @@ class StretchDriver(Node):
         self.declare_parameter('fail_out_of_range_goal', True)
         self.fail_out_of_range_goal = self.get_parameter('fail_out_of_range_goal').value
         
-        self.declare_parameter('action_server_rate', 15.0)
+        self.declare_parameter('action_server_rate', 30.0)
         self.action_server_rate = self.get_parameter('action_server_rate').value
 
         self.diagnostics = StretchDiagnostics(self, self.robot)


### PR DESCRIPTION
This PR implements a 30Hz fast stretch driver rates with the following changes:
- All publishing and Joint trajectory server rates are updated to 30Hz.
- All the robot push commands in various places are removed. Instead, all the robot command execution depends on the main [robot.push_command()](https://github.com/hello-robot/stretch_ros2/blob/75f71c335e7a75551f12195a720fcda3a1761b53/stretch_core/stretch_core/stretch_driver.py#L411) that is executed only once at 30Hz in the main thread.
- The Non-DXL status update thread is [disabled at robot startup](https://github.com/hello-robot/stretch_ros2/blob/75f71c335e7a75551f12195a720fcda3a1761b53/stretch_core/stretch_core/stretch_driver.py#L609:L611). Instead, it is [stepped](https://github.com/hello-robot/stretch_ros2/blob/75f71c335e7a75551f12195a720fcda3a1761b53/stretch_core/stretch_core/stretch_driver.py#L410) from the main thread to save system resources. 
- Presumes that Stretch Body is upgraded to 0.5 and the firmware to P3 (as these updates support the faster control rates). The driver node errors out and shutdown if below v0.5 stretch body is found.
