### PR TITLE
Add grasp object demo

### DIFF
--- a/stretch_core/stretch_core/keyboard_teleop.py
+++ b/stretch_core/stretch_core/keyboard_teleop.py
@@ -164,6 +164,11 @@ class GetKeyboardCommands:
             trigger_request = Trigger.Request() 
             trigger_result = node.trigger_clean_surface_service.call_async(trigger_request)
 
+        # Trigger grasp object demo    
+        if ((c == '\\') or (c == '\"')) and self.grasp_object_on:
+            trigger_request = Trigger.Request() 
+            trigger_result = node.trigger_grasp_object_service.call_async(trigger_request)
+
         ####################################################
         ## BASIC KEYBOARD TELEOPERATION COMMANDS
         ####################################################
@@ -231,6 +236,9 @@ class GetKeyboardCommands:
         if c == 'q' or c == 'Q':
             node.get_logger().info('keyboard_teleop exiting...')
             node.get_logger().info('Received quit character (q), so exiting')
+            node.destroy_node()
+            rclpy.shutdown()
+            sys.exit(0)
 
         ####################################################
 
@@ -266,8 +274,8 @@ class KeyboardTeleopNode(Node):
         self.joint_state = JointState()
         self.robot_mode = String()
 
-        if self.clean_surface_on:
-            self.get_logger().info("Clean surface demo enabled.")
+        if self.grasp_object_on:
+            self.get_logger().info("Grasp object demo enabled.")
         
     def joint_states_callback(self, joint_state):
         self.joint_state = joint_state
@@ -417,6 +425,11 @@ class KeyboardTeleopNode(Node):
             self.trigger_clean_surface_service = self.create_client(Trigger, '/clean_surface/trigger_clean_surface')
             self.trigger_clean_surface_service.wait_for_service()
             self.get_logger().info('Node ' + self.get_name() + ' connected to /clean_surface/trigger_clean_surface.')
+
+        if self.grasp_object_on:
+            self.trigger_grasp_object_service = self.create_client(Trigger, '/grasp_object/trigger_grasp_object')
+            self.trigger_grasp_object_service.wait_for_service()
+            self.get_logger().info('Node ' + self.get_name() + ' connected to /clean_surface/trigger_grasp_surface.')
 
         self.keys.print_commands()
         while rclpy.ok():

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -276,9 +276,15 @@ class StretchDriver(Node):
         runstop_event.data = robot_status['pimu']['runstop_event']
         self.runstop_event_pub.publish(runstop_event)
 
+        # publish stretch_driver operation mode
         mode_msg = String()
         mode_msg.data = self.robot_mode
         self.mode_pub.publish(mode_msg)
+
+        # publish end of arm tool
+        tool_msg = String()
+        tool_msg.data = self.robot.end_of_arm.name
+        self.tool_pub.publish(tool_msg)
 
         # publish joint state for the arm
         joint_state = JointState()
@@ -683,6 +689,7 @@ class StretchDriver(Node):
         self.power_pub = self.create_publisher(BatteryState, 'battery', 1)
         self.homed_pub = self.create_publisher(Bool, 'is_homed', 1)
         self.mode_pub = self.create_publisher(String, 'mode', 1)
+        self.tool_pub = self.create_publisher(String, 'tool', 1)
 
         self.imu_mobile_base_pub = self.create_publisher(Imu, 'imu_mobile_base', 1)
         self.magnetometer_mobile_base_pub = self.create_publisher(MagneticField, 'magnetometer_mobile_base', 1)

--- a/stretch_demos/launch/grasp_object.launch.py
+++ b/stretch_demos/launch/grasp_object.launch.py
@@ -1,0 +1,58 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch.substitutions import Command
+
+uncalibrated_controller_yaml_path = os.path.join(get_package_share_directory('stretch_core'), 'config', 'controller_calibration_head_factory_default.yaml')
+debug_directory_path = os.path.join(os.getenv('HELLO_FLEET_PATH'), 'debug') + '/' if os.getenv('HELLO_FLEET_PATH') else ''
+
+configurable_parameters = [{'name': 'uncalibrated_controller_yaml_file',               'default': uncalibrated_controller_yaml_path, 'description': 'directory path of the uncalibrated controller yaml file'},
+                           {'name': 'debug_directory',  'default': debug_directory_path, 'description': 'directory where debug imagery is saved'}]
+
+def declare_configurable_parameters(parameters):
+    return [DeclareLaunchArgument(param['name'], default_value=param['default'], description=param['description']) for param in parameters]
+
+def generate_launch_description():
+    debug_directory = LaunchConfiguration('debug_directory')
+    grasp_object_params = [
+        {'debug_directory': debug_directory,
+         'dryrun': False}
+    ]
+
+    d435i_high_res_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('stretch_core'), 'launch'),
+            '/d435i_high_resolution.launch.py']),
+        )
+
+    stretch_driver = IncludeLaunchDescription(
+          PythonLaunchDescriptionSource([os.path.join(
+               get_package_share_directory('stretch_core'), 'launch'),
+               '/stretch_driver.launch.py']),
+               launch_arguments={'broadcast_odom_tf': 'True'}.items()
+          )
+
+    stretch_funmap = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('stretch_funmap'), 'launch'),
+            '/funmap.launch.py']),
+        )
+
+    grasp_object = Node(
+            package='stretch_demos',
+            executable='grasp_object',
+            output='screen',
+            parameters=grasp_object_params,
+    )
+
+    return LaunchDescription(declare_configurable_parameters(configurable_parameters) + [
+        d435i_high_res_launch,
+        stretch_driver,
+        stretch_funmap,
+        grasp_object
+        ])

--- a/stretch_demos/setup.py
+++ b/stretch_demos/setup.py
@@ -26,6 +26,7 @@ setup(
         'console_scripts': [
             'clean_surface = stretch_demos.clean_surface:main',
             'open_drawer = stretch_demos.open_drawer:main',
+            'grasp_object = stretch_demos.grasp_object:main'
         ],
     },
 )

--- a/stretch_demos/stretch_demos/grasp_object.py
+++ b/stretch_demos/stretch_demos/grasp_object.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+
+from sensor_msgs.msg import JointState
+from geometry_msgs.msg import Twist
+from nav_msgs.msg import Odometry
+
+import rclpy
+from rclpy.node import Node
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.action import ActionClient, ActionServer
+from rclpy.duration import Duration
+from rclpy.executors import MultiThreadedExecutor
+import rclpy.logging
+from rclpy.time import Time
+
+from control_msgs.action import FollowJointTrajectory
+from trajectory_msgs.msg import JointTrajectoryPoint
+
+from sensor_msgs.msg import PointCloud2
+from std_msgs.msg import String
+from std_srvs.srv import Trigger
+
+import math
+import time
+import threading
+import sys
+import tf2_ros
+import argparse as ap        
+import numpy as np
+import os
+
+import hello_helpers.hello_misc as hm
+import stretch_funmap.navigate as nv
+import stretch_funmap.manipulation_planning as mp
+
+
+class GraspObjectNode(Node):
+
+    def __init__(self):
+        super().__init__('grasp_node')
+        self.rate = 10.0
+        self.joint_states = None
+        self.joint_states_lock = threading.Lock()
+        self.move_base = nv.MoveBase(self)
+        self.tool = None
+        self.letter_height_m = 0.2
+        self.wrist_position = None
+        self.lift_position = None
+        self.manipulation_view = None
+        self.debug_directory = None
+        self.tf2_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.transform_listener.TransformListener(self.tf2_buffer, self)
+        self.logger = self.get_logger()
+
+        self.move_to_pose_complete = False
+        self.unsuccessful_status = [-100, 100, FollowJointTrajectory.Result.PATH_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.INVALID_JOINTS, FollowJointTrajectory.Result.INVALID_GOAL, FollowJointTrajectory.Result.GOAL_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.OLD_HEADER_TIMESTAMP]
+        self._get_result_future = None
+
+        self.dryrun = False
+        
+    def joint_states_callback(self, joint_states):
+        with self.joint_states_lock: 
+            self.joint_states = joint_states
+        wrist_position, wrist_velocity, wrist_effort = hm.get_wrist_state(joint_states)
+        self.wrist_position = wrist_position
+        lift_position, lift_velocity, lift_effort = hm.get_lift_state(joint_states)
+        self.lift_position = lift_position
+        self.left_finger_position, temp1, temp2 = hm.get_left_finger_state(joint_states)
+
+    def point_cloud_callback(self, point_cloud):
+        self.point_cloud = point_cloud
+
+    def tool_callback(self, tool_string):
+        self.tool = tool_string.data
+
+    def get_tool(self):
+        assert(self.tool is not None)
+        return self.tool
+
+    def lower_tool_until_contact(self):
+        if (self.dryrun):
+            return
+
+        self.logger.info('lower_tool_until_contact')
+        trigger_request = Trigger.Request() 
+        trigger_result = self.trigger_lower_until_contact_service.call_async(trigger_request)
+        self.logger.info('trigger_result = {0}'.format(trigger_result))
+
+    def goal_response(self, future: rclpy.task.Future):
+        if not future or not future.result():
+            return False
+        goal_handle = future.result()
+        if not goal_handle.accepted:
+            self.move_to_pose_complete = True
+            return
+
+        self._get_result_future = goal_handle.get_result_async()
+
+    def get_result(self, future: rclpy.task.Future):
+        if not future or not future.result():
+            return
+
+        result = future.result().result
+        error_code = result.error_code
+        self.move_to_pose_complete = True
+
+    def move_to_pose(self, pose, return_before_done=False, custom_contact_thresholds=False):
+        if self.dryrun:
+            return None
+
+        self.move_to_pose_complete = False
+        joint_names = [key for key in pose]
+        point = JointTrajectoryPoint()
+        point.time_from_start = Duration(seconds=0.0).to_msg()
+
+        trajectory_goal = FollowJointTrajectory.Goal()
+        trajectory_goal.goal_time_tolerance = Duration(seconds=1.0).to_msg()
+        trajectory_goal.trajectory.joint_names = joint_names
+        if not custom_contact_thresholds: 
+            joint_positions = [pose[key] for key in joint_names]
+            point.positions = joint_positions
+            trajectory_goal.trajectory.points = [point]
+        else:
+            pose_correct = all([len(pose[key])==2 for key in joint_names])
+            if not pose_correct:
+                self.logger.error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
+                return
+            joint_positions = [pose[key][0] for key in joint_names]
+            joint_efforts = [pose[key][1] for key in joint_names]
+            point.positions = joint_positions
+            point.effort = joint_efforts
+            trajectory_goal.trajectory.points = [point]
+        trajectory_goal.trajectory.header.stamp = self.get_clock().now().to_msg()
+        self._send_goal_future = self.trajectory_client.send_goal_async(trajectory_goal)
+
+        if not return_before_done:
+            time_start = time.time()
+            self._get_result_future = None
+
+            while not self._get_result_future and (time.time() - time_start) < 10:
+                self.goal_response(self._send_goal_future)
+
+            if not self._get_result_future:
+                return self._send_goal_future
+
+            time_start = time.time()
+            while not self.move_to_pose_complete and (time.time() - time_start) < 10:
+                self.get_result(self._get_result_future)
+        
+        return self._send_goal_future
+
+    def look_at_surface(self, scan_time_s=None):
+        if self.dryrun:
+            return
+
+        self.manipulation_view = mp.ManipulationView(self.tf2_buffer, self.debug_directory, self.get_tool())
+        manip = self.manipulation_view
+        head_settle_time_s = 0.02 #1.0
+        manip.move_head(self.move_to_pose)
+        time.sleep(head_settle_time_s)
+        if scan_time_s is None:
+            manip.update(self.point_cloud, self.tf2_buffer)
+        else:
+            start_time_s = time.time()
+            while ((time.time() - start_time_s) < scan_time_s): 
+                manip.update(self.point_cloud, self.tf2_buffer)
+        if self.debug_directory is not None:
+            dirname = self.debug_directory + 'grasp_object/'
+            # If the directory does not already exist, create it.
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
+            filename = 'look_at_surface_' + hm.create_time_string()
+            manip.save_scan(dirname + filename)
+        else:
+            self.logger.info('GraspObjectNode: No debug directory provided, so debugging data will not be saved.')
+
+    def drive(self, forward_m):
+        if (self.dryrun):
+            return
+
+        tolerance_distance_m = 0.005
+        if forward_m > 0: 
+            at_goal = self.move_base.forward(forward_m, detect_obstacles=False, tolerance_distance_m=tolerance_distance_m)
+        else:
+            at_goal = self.move_base.backward(forward_m, detect_obstacles=False, tolerance_distance_m=tolerance_distance_m)
+
+    def stow_the_robot(self):
+        if (self.dryrun):
+            return
+
+        trigger_request = Trigger.Request()
+        self._send_goal_future = self.stow_the_robot_service.call(trigger_request)
+
+    def trigger_grasp_object_callback(self, request, response):
+        max_lift_m = 1.09
+        min_extension_m = 0.01
+        max_extension_m = 0.5
+
+        self.logger.info('Stow the arm.')
+        self.stow_the_robot()
+
+        # 1. Scan surface and find grasp target
+        self.look_at_surface(scan_time_s = 4.0)
+        grasp_target = self.manipulation_view.get_grasp_target(self.tf2_buffer)
+        if grasp_target is None:
+            return Trigger.Response(
+                success=False,
+                message='Failed to find grasp target'
+            )
+
+        # 2. Move to pregrasp pose
+        pregrasp_lift_m = self.manipulation_view.get_pregrasp_lift(grasp_target, self.tf2_buffer)
+        if self.tool == "tool_stretch_dex_wrist":
+            pregrasp_lift_m += 0.02
+        if (self.lift_position is None):
+            return Trigger.Response(
+                success=False,
+                message='lift position unavailable'
+            )
+        self.logger.info('Raise tool to pregrasp height.')
+        lift_to_pregrasp_m = max(self.lift_position + pregrasp_lift_m, 0.1)
+        lift_to_pregrasp_m = min(lift_to_pregrasp_m, max_lift_m)
+        pose = {'joint_lift': lift_to_pregrasp_m}
+        self.move_to_pose(pose)
+
+        if self.tool == "tool_stretch_dex_wrist":
+            self.logger.info('Rotate pitch/roll for grasping.')
+            pose = {'joint_wrist_pitch': -0.3, 'joint_wrist_roll': 0.0}
+            self.move_to_pose(pose)
+
+        pregrasp_yaw = self.manipulation_view.get_pregrasp_yaw(grasp_target, self.tf2_buffer)
+        self.logger.info('pregrasp_yaw = {0:.2f} rad'.format(pregrasp_yaw))
+        self.logger.info('pregrasp_yaw = {0:.2f} deg'.format(pregrasp_yaw * (180.0/np.pi)))
+        self.logger.info('Rotate the gripper for grasping.')
+        pose = {'joint_wrist_yaw': pregrasp_yaw}
+        self.move_to_pose(pose)
+
+        self.logger.info('Open the gripper.')
+        pose = {'gripper_aperture': 0.125}
+        self.move_to_pose(pose)
+
+        pregrasp_mobile_base_m, pregrasp_wrist_extension_m = self.manipulation_view.get_pregrasp_planar_translation(grasp_target, self.tf2_buffer)
+        self.logger.info('pregrasp_mobile_base_m = {0:.3f} m'.format(pregrasp_mobile_base_m))
+        self.logger.info('pregrasp_wrist_extension_m = {0:.3f} m'.format(pregrasp_wrist_extension_m))
+        self.logger.info('Drive to pregrasp location.')
+        self.drive(pregrasp_mobile_base_m)
+
+        if pregrasp_wrist_extension_m > 0.0:
+            extension_m = max(self.wrist_position + pregrasp_wrist_extension_m, min_extension_m)
+            extension_m = min(extension_m, max_extension_m)
+            self.logger.info('Extend tool above surface.')
+            pose = {'wrist_extension': extension_m}
+            self.move_to_pose(pose)
+        else:
+            self.logger.info('negative wrist extension for pregrasp, so not extending or retracting.')
+
+        # 3. Grasp the object and lift it
+        grasp_mobile_base_m, grasp_lift_m, grasp_wrist_extension_m = self.manipulation_view.get_grasp_from_pregrasp(grasp_target, self.tf2_buffer)
+        self.logger.info('grasp_mobile_base_m = {0:3f} m, grasp_lift_m = {1:3f} m, grasp_wrist_extension_m = {2:3f} m'.format(grasp_mobile_base_m, grasp_lift_m, grasp_wrist_extension_m))
+        self.logger.info('Move the grasp pose from the pregrasp pose.')
+
+        lift_m = max(self.lift_position + grasp_lift_m, 0.1)
+        lift_m = min(lift_m, max_lift_m)
+        extension_m = max(self.wrist_position + grasp_wrist_extension_m, min_extension_m)
+        extension_m = min(extension_m, max_extension_m)
+        pose = {'translate_mobile_base': grasp_mobile_base_m,
+                'joint_lift': lift_m,
+                'wrist_extension': extension_m}
+        self.move_to_pose(pose)
+
+        self.logger.info('Attempt to close the gripper on the object.')
+        gripper_aperture_m = grasp_target['width_m'] - 0.18
+        pose = {'gripper_aperture': gripper_aperture_m}
+        self.move_to_pose(pose)
+
+        # Lifting appears to happen before the gripper has
+        # finished unless there is this sleep. Need to look
+        # into this issue.
+        time.sleep(3.0)
+
+        self.logger.info('Attempt to lift the object.')
+        object_lift_height_m = 0.1
+        lift_m = max(self.lift_position + object_lift_height_m, 0.2)
+        lift_m = min(lift_m, max_lift_m)
+        pose = {'joint_lift': lift_m}
+        self.move_to_pose(pose)
+
+        self.logger.info('Open the gripper a little to avoid overtorquing and overheating the gripper motor.')
+        pose = {'gripper_aperture': gripper_aperture_m + 0.005}
+        self.move_to_pose(pose)
+
+        self.logger.info('Retract the tool.')
+        pose = {'wrist_extension': 0.01}
+        self.move_to_pose(pose)
+
+        self.logger.info('Reorient the wrist.')
+        pose = {'joint_wrist_yaw': 0.0}
+        self.move_to_pose(pose)
+
+        return Trigger.Response(
+            success=True,
+            message='Completed object grasp!'
+        )
+    
+    def main(self):
+        self.callback_group = ReentrantCallbackGroup()
+
+        self.declare_parameter('debug_directory', '')
+        self.debug_directory = self.get_parameter('debug_directory').value
+        self.logger.info('Using the following directory for debugging files: {0}'.format(self.debug_directory))
+
+        self.declare_parameter('dryrun', False)
+        self.dryrun = self.get_parameter('dryrun').value
+
+        self.joint_states_subscriber = self.create_subscription(JointState, '/stretch/joint_states', callback=self.joint_states_callback, qos_profile=1, callback_group=self.callback_group)
+
+        self.point_cloud_subscriber = self.create_subscription(PointCloud2, '/camera/depth/color/points', callback=self.point_cloud_callback, qos_profile=1, callback_group=self.callback_group)
+
+        self.tool_subscriber = self.create_subscription(String, '/tool', callback=self.tool_callback, qos_profile=1, callback_group=self.callback_group)
+
+        self.trigger_grasp_object_service = self.create_service(Trigger,
+                                                                '/grasp_object/trigger_grasp_object',
+                                                                callback=self.trigger_grasp_object_callback,
+                                                                callback_group=self.callback_group)
+
+        self.trigger_reach_until_contact_service = self.create_client(Trigger, '/funmap/trigger_reach_until_contact', callback_group=self.callback_group)
+        self.logger.info("Waiting for /funmap/trigger_reach_until_contact' service")
+        self.trigger_reach_until_contact_service.wait_for_service()
+        self.logger.info('Node ' + self.get_name() + ' connected to /funmap/trigger_reach_until_contact.')
+
+
+        self.trigger_lower_until_contact_service = self.create_client(Trigger, '/funmap/trigger_lower_until_contact', callback_group=self.callback_group)
+        self.logger.info("Waiting for /funmap/trigger_lower_until_contact' service")
+        self.trigger_lower_until_contact_service.wait_for_service()
+        self.logger.info('Node ' + self.get_name() + ' connected to /funmap/trigger_lower_until_contact.')
+
+        self.stow_the_robot_service = self.create_client(Trigger, '/stow_the_robot', callback_group=self.callback_group)
+        self.stow_the_robot_service.wait_for_service()
+        self.logger.info('Node ' + self.get_name() + ' connected to /stow_the_robot.')
+
+        self.trajectory_client = ActionClient(self, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory', callback_group=self.callback_group)
+        server_reached = self.trajectory_client.wait_for_server(timeout_sec=60.0)
+        if not server_reached:
+            self.get_logger().error('Unable to connect to joint_trajectory_server. Timeout exceeded.')
+            sys.exit()
+
+        self.logger.info("Grasp object node is ready!")
+
+def main():
+    try:
+        rclpy.init()
+        node = GraspObjectNode()
+        node.main()
+        executor = MultiThreadedExecutor(num_threads=6)
+        executor.add_node(node=node)
+        try:
+            executor.spin()
+        finally:
+            executor.shutdown()
+            node.destroy_node()
+            rclpy.shutdown()
+    except KeyboardInterrupt:
+        rclpy.logging.get_logger('grasp_object').info('interrupt received, so shutting down')
+
+if __name__ == '__main__':
+    main()

--- a/stretch_demos/stretch_demos/open_drawer.py
+++ b/stretch_demos/stretch_demos/open_drawer.py
@@ -282,16 +282,18 @@ class OpenDrawerNode(Node):
 
 
 def main():
+    rclpy.init()
     try:
-        rclpy.init()
-        parser = ap.ArgumentParser(description='Open Drawer behavior for stretch.')
-        #parser.add_argument('--mapping_on', action='store_true', help='Turn on mapping control. For example, the space bar will trigger a head scan. This requires that the mapping node be run (funmap).')
-        args, unknown = parser.parse_known_args()
         node = OpenDrawerNode()
         node.main()
         executor = MultiThreadedExecutor(num_threads=6)
         executor.add_node(node=node)
-        executor.spin()
+        try:
+            executor.spin()
+        finally:
+            executor.shutdown()
+            node.destroy_node()
+            rclpy.shutdown()
     except KeyboardInterrupt:
         rclpy.logging.get_logger('open_drawer').info('interrupt received, so shutting down')
 

--- a/stretch_funmap/stretch_funmap/funmap.py
+++ b/stretch_funmap/stretch_funmap/funmap.py
@@ -259,10 +259,10 @@ class FunmapNode(Node):
                 av_effort_threshold = 34.0
 
                 if (effort >= single_effort_threshold):
-                    self.logger.info('Extension single effort exceeded single_effort_threshold: {0} >= {1}'.format(
+                    self.logger.debug('Extension single effort exceeded single_effort_threshold: {0} >= {1}'.format(
                         effort, single_effort_threshold))
                 if (av_effort >= av_effort_threshold):
-                    self.logger.info('Extension average effort exceeded av_effort_threshold: {0} >= {1}'.format(
+                    self.logger.debug('Extension average effort exceeded av_effort_threshold: {0} >= {1}'.format(
                         av_effort, av_effort_threshold))
 
                 return ((effort >= single_effort_threshold) or
@@ -277,10 +277,10 @@ class FunmapNode(Node):
                 av_effort_threshold = 40.0
 
                 if (effort >= single_effort_threshold):
-                    self.logger.info('Extension single effort exceeded single_effort_threshold: {0} >= {1}'.format(
+                    self.logger.debug('Extension single effort exceeded single_effort_threshold: {0} >= {1}'.format(
                         effort, single_effort_threshold))
                 if (av_effort >= av_effort_threshold):
-                    self.logger.info('Extension average effort exceeded av_effort_threshold: {0} >= {1}'.format(
+                    self.logger.debug('Extension average effort exceeded av_effort_threshold: {0} >= {1}'.format(
                         av_effort, av_effort_threshold))
 
                 return ((effort >= single_effort_threshold) or
@@ -294,10 +294,10 @@ class FunmapNode(Node):
             av_effort_threshold = 20.0
 
             if (effort <= single_effort_threshold):
-                self.logger.info('Lift single effort less than single_effort_threshold: {0} <= {1}'.format(
+                self.logger.debug('Lift single effort less than single_effort_threshold: {0} <= {1}'.format(
                     effort, single_effort_threshold))
             if (av_effort <= av_effort_threshold):
-                self.logger.info('Lift average effort less than av_effort_threshold: {0} <= {1}'.format(
+                self.logger.debug('Lift average effort less than av_effort_threshold: {0} <= {1}'.format(
                     av_effort, av_effort_threshold))
 
             return ((effort <= single_effort_threshold) or

--- a/stretch_funmap/stretch_funmap/manipulation_planning.py
+++ b/stretch_funmap/stretch_funmap/manipulation_planning.py
@@ -206,11 +206,18 @@ def detect_cliff(image, m_per_pix, m_per_height_unit, robot_xy_pix, display_text
     
 
 class ManipulationView():
-    def __init__(self, tf2_buffer, debug_directory=None):
+    def __init__(self, tf2_buffer, debug_directory=None, tool='tool_stretch_gripper'):
         self.debug_directory = debug_directory
         self.logger = rclpy.logging.get_logger('stretch_funmap')
         self.logger.info(f"ManipulationView __init__: self.debug_directory = {str(self.debug_directory)}")
-        
+
+        # Define gripper links and tool type
+        self.gripper_links = {
+            'tool_stretch_gripper': 'link_gripper',
+            'tool_stretch_dex_wrist': 'link_straight_gripper_aligned'
+        }
+        self.tool = tool
+
         # Define the volume of interest for planning using the current
         # view.
         
@@ -433,7 +440,7 @@ class ManipulationView():
         # The planar component of the link gripper x_axis is parallel
         # to the middle of the gripper, but points in the opposite
         # direction.
-        gripper_frame = 'link_gripper'
+        gripper_frame = self.gripper_links[self.tool]
         gripper_points_to_image_mat, ip_timestamp = h.get_points_to_image_mat(gripper_frame, tf2_buffer)
         #
         # forward_direction = np.array([1.0, 0.0, 0.0])
@@ -482,7 +489,7 @@ class ManipulationView():
         # The planar component of the link gripper x_axis is parallel
         # to the middle of the gripper, but points in the opposite
         # direction.
-        gripper_frame = 'link_gripper'
+        gripper_frame = self.gripper_links[self.tool]
         gripper_points_to_image_mat, ip_timestamp = h.get_points_to_image_mat(gripper_frame, tf2_buffer)
 
         # Obtain the gripper yaw axis location in the image by
@@ -595,7 +602,7 @@ class ManipulationView():
         # The planar component of the link gripper x_axis is parallel
         # to the middle of the gripper, but points in the opposite
         # direction.
-        gripper_frame = 'link_gripper'
+        gripper_frame = self.gripper_links[self.tool]
         gripper_points_to_image_mat, ip_timestamp = h.get_points_to_image_mat(gripper_frame, tf2_buffer)
 
         # Obtain the gripper yaw axis location in the image by

--- a/stretch_funmap/stretch_funmap/navigate.py
+++ b/stretch_funmap/stretch_funmap/navigate.py
@@ -224,7 +224,7 @@ class MoveBase():
 
     def goal_response(self, future: rclpy.task.Future):
         self._get_result_future = None
-        if not future.result():
+        if not future or not future.result():
             return False
         goal_handle = future.result()
         if not goal_handle.accepted:
@@ -235,7 +235,7 @@ class MoveBase():
         return True
 
     def get_result(self, future: rclpy.task.Future):
-        if not future.result():
+        if not future or not future.result():
             return
 
         result = future.result().result


### PR DESCRIPTION
## Summary

This PR adds an object grasping demo with dexwrist support, similar to ROS 1.

## How-to-test

Launch the object grasping demo:
```
ros2 launch stretch_demos grasp_object.launch.py
```

Next, run the keyboard teleop node in a new terminal with object grasping services turned on:
```
ros2 run stretch_core keyboard_teleop --ros-args -p grasp_object_on:=true
```

You can now start the demo by pressing the "\\" key.