### PR TITLE
Add PointField datatypes to create pointclouds in Deep Perception

### DIFF
--- a/stretch_deep_perception/stretch_deep_perception/detection_node.py
+++ b/stretch_deep_perception/stretch_deep_perception/detection_node.py
@@ -156,6 +156,14 @@ class DetectionNode:
         is_bigendian = False
         field_names = None
         _DATATYPES = {}
+        _DATATYPES[PointField.INT8]    = ('b', 1)
+        _DATATYPES[PointField.UINT8]   = ('B', 1)
+        _DATATYPES[PointField.INT16]   = ('h', 2)
+        _DATATYPES[PointField.UINT16]  = ('H', 2)
+        _DATATYPES[PointField.INT32]   = ('i', 4)
+        _DATATYPES[PointField.UINT32]  = ('I', 4)
+        _DATATYPES[PointField.FLOAT32] = ('f', 4)
+        _DATATYPES[PointField.FLOAT64] = ('d', 8)
 
         fmt = '>' if is_bigendian else '<'
         offset = 0


### PR DESCRIPTION
## Summary

This PR populates the `_DATATYPES` dictionary while creating a point cloud within `DetectionNode` for Deep Perception. See [sensor_msgs.point_cloud2#L52-59](https://github.com/ros/common_msgs/blob/20a833b56f9d7fd39655b8491a2ec1226d2639b3/sensor_msgs/src/sensor_msgs/point_cloud2.py#L52-L59) for reference.

## How-to-test

Launch any stretch_deep_perception node that produces a point cloud, for example:
```
ros2 launch stretch_deep_perception stretch_detect_body_landmarks.launch.py
```
