### PR TITLE
Update demos to work with HelloNode

### DIFF
--- a/hello_helpers/src/hello_helpers/hello_misc.py
+++ b/hello_helpers/src/hello_helpers/hello_misc.py
@@ -284,7 +284,7 @@ class HelloNode(Node):
     
     def main(self, node_name, node_topic_namespace, wait_for_first_pointcloud=True):
         rclpy.init()
-        self.node = rclpy.create_node(node_name)
+        self.node = rclpy.create_node(node_name, allow_undeclared_parameters=True, automatically_declare_parameters_from_overrides=True)
         self.node_name = node_name
         self.node.get_logger().info("{0} started".format(self.node_name))
         

--- a/hello_helpers/src/hello_helpers/hello_misc.py
+++ b/hello_helpers/src/hello_helpers/hello_misc.py
@@ -172,8 +172,8 @@ class HelloNode(Node):
             return
         
         if self.mode.data not in ['trajectory', 'position']:
-            self.node.get_logger().warn("Currently in {} mode. Recommend switching either to position or trajectory mode".format(self.mode.data))
-            self.node.get_logger().warn("Commanding joint trajectory server in position mode")
+            self.get_logger().warn("Currently in {} mode. Recommend switching either to position or trajectory mode".format(self.mode.data))
+            self.get_logger().warn("Commanding joint trajectory server in position mode")
         
         joint_names = [key for key in pose]
         point1 = JointTrajectoryPoint()
@@ -200,7 +200,7 @@ class HelloNode(Node):
         else:
             pose_correct = all([len(pose[key])==2 for key in joint_names])
             if not pose_correct:
-                self.node.get_logger().error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
+                self.get_logger().error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
                 return
             joint_positions = [pose[key][0] for key in joint_names]
             joint_efforts = [pose[key][1] for key in joint_names]
@@ -219,7 +219,7 @@ class HelloNode(Node):
         try:
             return self.tf2_buffer.lookup_transform(from_frame, to_frame, Time(), timeout=Duration(seconds=2.0))
         except:
-            self.node.get_logger().warn("Could not find the transform between frames {} and {}".format(from_frame, to_frame))
+            self.get_logger().warn("Could not find the transform between frames {} and {}".format(from_frame, to_frame))
 
     def home_the_robot(self):
         if self.dryrun:
@@ -229,7 +229,7 @@ class HelloNode(Node):
         trigger_result = self.home_the_robot_service.call_async(trigger_request)
         while not trigger_result.done():
             time.sleep(0.2)
-        self.node.get_logger().debug(f"{self.node_name}'s HelloNode.home_the_robot: got message {trigger_result.done()}")
+        self.get_logger().debug(f"{self.node_name}'s HelloNode.home_the_robot: got message {trigger_result.done()}")
         return trigger_result.done()
 
     def stow_the_robot(self):
@@ -240,7 +240,7 @@ class HelloNode(Node):
         trigger_result = self.stow_the_robot_service.call_async(trigger_request)
         while not trigger_result.done():
             time.sleep(0.2)
-        self.node.get_logger().debug(f"{self.node_name}'s HelloNode.stow_the_robot: got message {trigger_result.done()}")
+        self.get_logger().debug(f"{self.node_name}'s HelloNode.stow_the_robot: got message {trigger_result.done()}")
         return trigger_result.done()
 
     def stop_the_robot(self):
@@ -248,7 +248,7 @@ class HelloNode(Node):
         trigger_result = self.stop_the_robot_service.call_async(trigger_request)
         while not trigger_result.done():
             time.sleep(0.2)
-        self.node.get_logger().debug(f"{self.node_name}'s HelloNode.stop_the_robot: got message {trigger_result.done()}")
+        self.get_logger().debug(f"{self.node_name}'s HelloNode.stop_the_robot: got message {trigger_result.done()}")
         return trigger_result.done()
     
     def switch_to_trajectory_mode(self):
@@ -256,7 +256,7 @@ class HelloNode(Node):
         trigger_result = self.switch_to_trajectory_mode_service.call_async(trigger_request)
         while not trigger_result.done():
             time.sleep(0.2)
-        self.node.get_logger().debug(f"{self.node_name}'s HelloNode.switch_to_trajectory_mode: got message {trigger_result.done()}")
+        self.get_logger().debug(f"{self.node_name}'s HelloNode.switch_to_trajectory_mode: got message {trigger_result.done()}")
         return trigger_result.done()
     
     def switch_to_position_mode(self):
@@ -264,7 +264,7 @@ class HelloNode(Node):
         trigger_result = self.switch_to_position_mode_service.call_async(trigger_request)
         while not trigger_result.done():
             time.sleep(0.2)
-        self.node.get_logger().debug(f"{self.node_name}'s HelloNode.switch_to_position_mode: got message {trigger_result.done()}")
+        self.get_logger().debug(f"{self.node_name}'s HelloNode.switch_to_position_mode: got message {trigger_result.done()}")
         return trigger_result.done()
     
     def switch_to_navigation_mode(self):
@@ -272,11 +272,11 @@ class HelloNode(Node):
         trigger_result = self.switch_to_navigation_mode_service.call_async(trigger_request)
         while not trigger_result.done():
             time.sleep(0.2)
-        self.node.get_logger().debug(f"{self.node_name}'s HelloNode.switch_to_navigation_mode: got message {trigger_result.done()}")
+        self.get_logger().debug(f"{self.node_name}'s HelloNode.switch_to_navigation_mode: got message {trigger_result.done()}")
         return trigger_result.done()
 
-    def get_logger(self):
-        return self.node.get_logger()
+    # def get_logger(self):
+    #     return self.get_logger()
     
     def get_tool(self):
         assert(self.tool is not None)
@@ -284,73 +284,74 @@ class HelloNode(Node):
     
     def main(self, node_name, node_topic_namespace, wait_for_first_pointcloud=True):
         rclpy.init()
-        self.node = rclpy.create_node(node_name, allow_undeclared_parameters=True, automatically_declare_parameters_from_overrides=True)
+        super().__init__(node_name, allow_undeclared_parameters=True, automatically_declare_parameters_from_overrides=True)
+        
         self.node_name = node_name
-        self.node.get_logger().info("{0} started".format(self.node_name))
+        self.get_logger().info("{0} started".format(self.node_name))
         
         executor = MultiThreadedExecutor()
-        executor.add_node(self.node)
+        executor.add_node(self)
         
         self.new_thread = threading.Thread(target=self.spin_thread, args=(executor, ), daemon=True)
         self.new_thread.start()
 
         reentrant_cb = ReentrantCallbackGroup()
 
-        self.trajectory_client = ActionClient(self.node, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory', callback_group=reentrant_cb)
+        self.trajectory_client = ActionClient(self, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory', callback_group=reentrant_cb)
         server_reached = self.trajectory_client.wait_for_server(timeout_sec=60.0)
         if not server_reached:
-            self.node.get_logger().error('Unable to connect to arm action server. Timeout exceeded.')
+            self.get_logger().error('Unable to connect to arm action server. Timeout exceeded.')
             sys.exit()
         
         self.tf2_buffer = tf2_ros.Buffer()
-        self.tf2_listener = tf2_ros.TransformListener(self.tf2_buffer, self.node)
+        self.tf2_listener = tf2_ros.TransformListener(self.tf2_buffer, self)
         
-        self.tool_subscriber = self.node.create_subscription(String, '/tool', self.tool_callback, 10, callback_group=reentrant_cb)
+        self.tool_subscriber = self.create_subscription(String, '/tool', self.tool_callback, 10, callback_group=reentrant_cb)
 
-        self.joint_states_subscriber = self.node.create_subscription(JointState, '/stretch/joint_states', self.joint_states_callback, 10, callback_group=reentrant_cb)
-        self.mode_subscriber = self.node.create_subscription(String, '/mode', self.mode_callback, 10, callback_group=reentrant_cb)
+        self.joint_states_subscriber = self.create_subscription(JointState, '/stretch/joint_states', self.joint_states_callback, 10, callback_group=reentrant_cb)
+        self.mode_subscriber = self.create_subscription(String, '/mode', self.mode_callback, 10, callback_group=reentrant_cb)
         
-        self.point_cloud_subscriber = self.node.create_subscription(PointCloud2, '/camera/depth/color/points', self.point_cloud_callback, 10, callback_group=reentrant_cb)
-        self.point_cloud_pub = self.node.create_publisher(PointCloud2, '/' + node_topic_namespace + '/point_cloud2', 10, callback_group=reentrant_cb)
+        self.point_cloud_subscriber = self.create_subscription(PointCloud2, '/camera/depth/color/points', self.point_cloud_callback, 10, callback_group=reentrant_cb)
+        self.point_cloud_pub = self.create_publisher(PointCloud2, '/' + node_topic_namespace + '/point_cloud2', 10, callback_group=reentrant_cb)
 
-        self.home_the_robot_service = self.node.create_client(Trigger, '/home_the_robot', callback_group=reentrant_cb)
+        self.home_the_robot_service = self.create_client(Trigger, '/home_the_robot', callback_group=reentrant_cb)
         while not self.home_the_robot_service.wait_for_service(timeout_sec=2.0):
-            self.node.get_logger().info("Waiting on '/home_the_robot' service...")
-        self.node.get_logger().info('Node ' + self.node_name + ' connected to /home_the_robot service.')
+            self.get_logger().info("Waiting on '/home_the_robot' service...")
+        self.get_logger().info('Node ' + self.node_name + ' connected to /home_the_robot service.')
 
-        self.stow_the_robot_service = self.node.create_client(Trigger, '/stow_the_robot', callback_group=reentrant_cb)
+        self.stow_the_robot_service = self.create_client(Trigger, '/stow_the_robot', callback_group=reentrant_cb)
         while not self.stow_the_robot_service.wait_for_service(timeout_sec=2.0):
-            self.node.get_logger().info("Waiting on '/stow_the_robot' service...")
-        self.node.get_logger().info('Node ' + self.node_name + ' connected to /stow_the_robot service.')
+            self.get_logger().info("Waiting on '/stow_the_robot' service...")
+        self.get_logger().info('Node ' + self.node_name + ' connected to /stow_the_robot service.')
         
-        self.stop_the_robot_service = self.node.create_client(Trigger, '/stop_the_robot', callback_group=reentrant_cb)
+        self.stop_the_robot_service = self.create_client(Trigger, '/stop_the_robot', callback_group=reentrant_cb)
         while not self.stop_the_robot_service.wait_for_service(timeout_sec=2.0):
-            self.node.get_logger().info("Waiting on '/stop_the_robot' service...")
-        self.node.get_logger().info('Node ' + self.node_name + ' connected to /stop_the_robot service.')
+            self.get_logger().info("Waiting on '/stop_the_robot' service...")
+        self.get_logger().info('Node ' + self.node_name + ' connected to /stop_the_robot service.')
 
-        self.switch_to_trajectory_mode_service = self.node.create_client(Trigger, '/switch_to_trajectory_mode', callback_group=reentrant_cb)
+        self.switch_to_trajectory_mode_service = self.create_client(Trigger, '/switch_to_trajectory_mode', callback_group=reentrant_cb)
         while not self.switch_to_trajectory_mode_service.wait_for_service(timeout_sec=2.0):
-            self.node.get_logger().info("Waiting on '/switch_to_trajectory_mode' service...")
-        self.node.get_logger().info('Node ' + self.node_name + ' connected to /switch_to_trajectory_mode service.')
+            self.get_logger().info("Waiting on '/switch_to_trajectory_mode' service...")
+        self.get_logger().info('Node ' + self.node_name + ' connected to /switch_to_trajectory_mode service.')
 
-        self.switch_to_position_mode_service = self.node.create_client(Trigger, '/switch_to_position_mode', callback_group=reentrant_cb)
+        self.switch_to_position_mode_service = self.create_client(Trigger, '/switch_to_position_mode', callback_group=reentrant_cb)
         while not self.switch_to_position_mode_service.wait_for_service(timeout_sec=2.0):
-            self.node.get_logger().info("Waiting on '/switch_to_position_mode' service...")
-        self.node.get_logger().info('Node ' + self.node_name + ' connected to /switch_to_position_mode service.')
+            self.get_logger().info("Waiting on '/switch_to_position_mode' service...")
+        self.get_logger().info('Node ' + self.node_name + ' connected to /switch_to_position_mode service.')
 
-        self.switch_to_navigation_mode_service = self.node.create_client(Trigger, '/switch_to_navigation_mode', callback_group=reentrant_cb)
+        self.switch_to_navigation_mode_service = self.create_client(Trigger, '/switch_to_navigation_mode', callback_group=reentrant_cb)
         while not self.switch_to_navigation_mode_service.wait_for_service(timeout_sec=2.0):
-            self.node.get_logger().info("Waiting on '/switch_to_navigation_mode' service...")
-        self.node.get_logger().info('Node ' + self.node_name + ' connected to /switch_to_navigation_mode service.')
+            self.get_logger().info("Waiting on '/switch_to_navigation_mode' service...")
+        self.get_logger().info('Node ' + self.node_name + ' connected to /switch_to_navigation_mode service.')
         
         if wait_for_first_pointcloud:
             # Do not start until a point cloud has been received
             point_cloud_msg = self.point_cloud
-            self.node.get_logger().info('Node ' + node_name + ' waiting to receive first point cloud.')
+            self.get_logger().info('Node ' + node_name + ' waiting to receive first point cloud.')
             while point_cloud_msg is None:
                 time.sleep(0.1)
                 point_cloud_msg = self.point_cloud
-            self.node.get_logger().info('Node ' + node_name + ' received first point cloud, so continuing.')
+            self.get_logger().info('Node ' + node_name + ' received first point cloud, so continuing.')
 
 
 def create_time_string():

--- a/stretch_demos/README.md
+++ b/stretch_demos/README.md
@@ -69,6 +69,25 @@ ros2 run stretch_core keyboard_teleop --ros-args -p clean_surface_on:=True
 ```
 Then, press the key with the / and ? on it while in the terminal to initiate a surface cleaning attempt.
 
+### Open Drawer Demo
+
+For this demonstration, the robot will use contact detection with its arm to attempt to open a drawer. Prior to running the demo, you should move the robot so that its workspace will be able to move its arm towards a drawer while extending its arm. 
+
+The robot will not use the camera to detect the drawer, so ensure that there are no obstacles in the way.
+
+Now that the robot is ready, launch the demo with the following command:
+
+```
+ros2 launch stretch_demos open_drawer.launch.py
+```
+
+Launch the keyboard teleop node with the open_drawer param set as True in a separate terminal:
+```
+ros2 run stretch_core keyboard_teleop --ros-args -p open_drawer_on:=True
+```
+Then, press the 'z' or 'Z' key while in the terminal to initiate an open drawer with downward hook motion.
+Alternatively, press the '.' or '>' key while in the terminal to initiate an open drawer with upward hook motion.
+
 <!-- ### Autodocking with Nav Stack
 
 For this demo, the robot will look for a docking station with an ArUco marker, align itself to the docking station using the ROS Nav Stack, and then back up into the docking station using an error-based controller. Prior to running this demo, you should stow the robot, ensure that you have a pregenerated map and the docking station is resting against a wall. Go through [this](https://docs.hello-robot.com/0.2/stretch-tutorials/ros1/autodocking_nav_stack/) tutorial to understand how the demo works.

--- a/stretch_demos/README.md
+++ b/stretch_demos/README.md
@@ -16,6 +16,11 @@ First, place the robot near you so that it can freely move back and forth and re
 ros2 launch stretch_demos handover_object.launch.py
 ```
 
+Launch the keyboard teleop node with the handover_object param set as True in a separate terminal:
+```
+ros2 run stretch_core keyboard_teleop --ros-args -p handover_object_on:=True
+```
+
 For this demonstration, the robot will pan its head back and forth looking for a face. It will remember the 3D location of the mouth of the nearest face that it has detected. If you press "y" or "Y" on the keyboard in the terminal, the robot will move the grasp region of its gripper toward a handover location below and away from the mouth. 
 
 The robot will restrict itself to Cartesian motion to do this. Specifically, it will move its mobile base backward and forward, its lift up and down, and its arm in and out. If you press "y" or "Y" again, it will retract its arm and then move to the most recent mouth location it has detected. 
@@ -34,7 +39,7 @@ Now that the robot is ready, launch the demo with the following command:
 ros2 launch stretch_demos grasp_object.launch.py
 ```
 
-Launch the keyboard teleop node with the grasp_object_param set as True in a separate terminal:
+Launch the keyboard teleop node with the grasp_object param set as True in a separate terminal:
 ```
 ros2 run stretch_core keyboard_teleop --ros-args -p grasp_object_on:=True
 ```
@@ -57,6 +62,11 @@ Now that the robot is ready, launch the demo with the following command:
 ros2 launch stretch_demos clean_surface.launch.py
 ```
 
+
+Launch the keyboard teleop node with the clean_surface param set as True in a separate terminal:
+```
+ros2 run stretch_core keyboard_teleop --ros-args -p clean_surface_on:=True
+```
 Then, press the key with the / and ? on it while in the terminal to initiate a surface cleaning attempt.
 
 <!-- ### Autodocking with Nav Stack

--- a/stretch_demos/README.md
+++ b/stretch_demos/README.md
@@ -34,6 +34,11 @@ Now that the robot is ready, launch the demo with the following command:
 ros2 launch stretch_demos grasp_object.launch.py
 ```
 
+Launch the keyboard teleop node with the grasp_object_param set as True in a separate terminal:
+```
+ros2 run stretch_core keyboard_teleop --ros-args -p grasp_object_on:=True
+```
+
 Then, press the key with ‘ and “ on it while in the terminal to initiate a grasp attempt.
 
 While attempting the grasp the demo will save several images under the ./stretch_user/debug/ directory within various grasping related directories. You can view these images to see some of what the robot did to make its decisions.

--- a/stretch_demos/launch/grasp_object.launch.py
+++ b/stretch_demos/launch/grasp_object.launch.py
@@ -50,9 +50,16 @@ def generate_launch_description():
             parameters=grasp_object_params,
     )
 
+    static_tf_straight_gripper_aligned = Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            arguments = ['--x', '0', '--y', '0', '--z', '0', '--yaw', '0', '--pitch', '1.5707963', '--roll', '1.5707963', '--frame-id', 'link_straight_gripper', '--child-frame-id', 'link_straight_gripper_aligned']
+        )
+
     return LaunchDescription(declare_configurable_parameters(configurable_parameters) + [
         d435i_high_res_launch,
         stretch_driver,
         stretch_funmap,
-        grasp_object
+        grasp_object,
+        static_tf_straight_gripper_aligned
         ])

--- a/stretch_demos/stretch_demos/clean_surface.py
+++ b/stretch_demos/stretch_demos/clean_surface.py
@@ -12,9 +12,8 @@ import os
 
 import hello_helpers.hello_misc as hm
 import stretch_funmap.manipulation_planning as mp
-from hello_helpers.hello_misc import HelloNode
 
-class CleanSurfaceNode(HelloNode):
+class CleanSurfaceNode(hm.HelloNode):
     def __init__(self):
         hm.HelloNode.__init__(self)
         self.rate = 10.0

--- a/stretch_demos/stretch_demos/clean_surface.py
+++ b/stretch_demos/stretch_demos/clean_surface.py
@@ -1,54 +1,32 @@
 #!/usr/bin/env python3
 
 import rclpy
-from rclpy.action import ActionClient, ActionServer
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.duration import Duration
-from rclpy.executors import MultiThreadedExecutor
-from rclpy.node import Node
-from rclpy.time import Time
-from control_msgs.action import FollowJointTrajectory
-from trajectory_msgs.msg import JointTrajectoryPoint
 
-from geometry_msgs.msg import Twist
-from nav_msgs.msg import Odometry
-from sensor_msgs.msg import PointCloud2
 from sensor_msgs.msg import JointState
 from std_srvs.srv import Trigger
 
-import math
 import time
 import threading
-import sys
 import os
-import tf2_ros
-import argparse as ap
 
 import hello_helpers.hello_misc as hm
 import stretch_funmap.manipulation_planning as mp
+from hello_helpers.hello_misc import HelloNode
 
-
-class CleanSurfaceNode(Node):
+class CleanSurfaceNode(HelloNode):
     def __init__(self):
-        super().__init__('clean_surface')
+        hm.HelloNode.__init__(self)
         self.rate = 10.0
         self.joint_states = None
         self.joint_states_lock = threading.Lock()
-        self.point_cloud = None
         # self.move_base = nv.MoveBase(self)
         self.letter_height_m = 0.2
         self.wrist_position = None
         self.lift_position = None
         self.manipulation_view = None
         self.debug_directory = None
-        self.tf2_buffer = tf2_ros.Buffer()
-        self.tf_listener = tf2_ros.transform_listener.TransformListener(self.tf2_buffer, self)
-        self.log = self.get_logger()
 
-        self.move_to_pose_complete = False
-        self.unsuccessful_status = [-100, 100, FollowJointTrajectory.Result.PATH_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.INVALID_JOINTS, FollowJointTrajectory.Result.INVALID_GOAL, FollowJointTrajectory.Result.GOAL_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.OLD_HEADER_TIMESTAMP]
-        self._get_result_future = None
-        
     def joint_states_callback(self, joint_states):
         with self.joint_states_lock:
             self.joint_states = joint_states
@@ -56,70 +34,6 @@ class CleanSurfaceNode(Node):
         self.wrist_position = wrist_position
         lift_position, lift_velocity, lift_effort = hm.get_lift_state(joint_states)
         self.lift_position = lift_position
-
-    def point_cloud_callback(self, point_cloud):
-        self.point_cloud = point_cloud
-
-    def goal_response(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            # self.logger.info("Future goal result is not set")
-            return False
-        goal_handle = future.result()
-        if not goal_handle.accepted:
-            self.move_to_pose_complete = True
-            return
-
-        self._get_result_future = goal_handle.get_result_async()
-
-    def get_result(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return
-
-        result = future.result().result
-        error_code = result.error_code
-        self.move_to_pose_complete = True
-    
-    def move_to_pose(self, pose, return_before_done=False, custom_contact_thresholds=False):
-        self.move_to_pose_complete = False
-        joint_names = [key for key in pose]
-        point = JointTrajectoryPoint()
-        point.time_from_start = Duration(seconds=0.0).to_msg()
-
-        trajectory_goal = FollowJointTrajectory.Goal()
-        trajectory_goal.goal_time_tolerance = Duration(seconds=1.0).to_msg()
-        trajectory_goal.trajectory.joint_names = joint_names
-        if not custom_contact_thresholds: 
-            joint_positions = [pose[key] for key in joint_names]
-            point.positions = joint_positions
-            trajectory_goal.trajectory.points = [point]
-        else:
-            pose_correct = all([len(pose[key])==2 for key in joint_names])
-            if not pose_correct:
-                self.logger.error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
-                return
-            joint_positions = [pose[key][0] for key in joint_names]
-            joint_efforts = [pose[key][1] for key in joint_names]
-            point.positions = joint_positions
-            point.effort = joint_efforts
-            trajectory_goal.trajectory.points = [point]
-        trajectory_goal.trajectory.header.stamp = self.get_clock().now().to_msg()
-        self._send_goal_future = self.trajectory_client.send_goal_async(trajectory_goal)
-
-        if not return_before_done:
-            time_start = time.time()
-            self._get_result_future = None
-
-            while not self._get_result_future and (time.time() - time_start) < 10:
-                self.goal_response(self._send_goal_future)
-
-            if not self._get_result_future:
-                return self._send_goal_future
-
-            time_start = time.time()
-            while not self.move_to_pose_complete and (time.time() - time_start) < 10:
-                self.get_result(self._get_result_future)
-        
-        return self._send_goal_future
 
     def wipe_in(self):
         self.log.info('wipe_in')
@@ -266,42 +180,29 @@ class CleanSurfaceNode(Node):
         return response
     
     def main(self):
+        hm.HelloNode.main(self, 'clean_surface', 'clean_surface', wait_for_first_pointcloud=False)
+
+        self.log = self.get_logger()
         self.callback_group = ReentrantCallbackGroup()
 
-        self.declare_parameter('debug_directory', '')
         self.debug_directory = self.get_parameter('debug_directory').value
         self.log.info('Using the following directory for debugging files: {0}'.format(self.debug_directory))
 
         self.joint_states_subscriber = self.create_subscription(JointState, '/stretch/joint_states', callback=self.joint_states_callback, qos_profile=10, callback_group=self.callback_group)
-
-        self.point_cloud_subscriber = self.create_subscription(PointCloud2, '/camera/depth/color/points', callback=self.point_cloud_callback, qos_profile=10, callback_group=self.callback_group)
 
         self.trigger_clean_surface_service = self.create_service(Trigger,
                                                                 '/clean_surface/trigger_clean_surface',
                                                                 callback=self.trigger_clean_surface_callback,
                                                                 callback_group=self.callback_group)
 
-        self.trajectory_client = ActionClient(self, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory', callback_group=self.callback_group)
-        server_reached = self.trajectory_client.wait_for_server(timeout_sec=60.0)
-        if not server_reached:
-            self.get_logger().error('Unable to connect to joint_trajectory_server. Timeout exceeded.')
-            sys.exit()
-
         self.log.info("Clean surface node is ready!")
 
 def main():
-    rclpy.init()
     try:
         node = CleanSurfaceNode()
         node.main()
-        executor = MultiThreadedExecutor(num_threads=6)
-        executor.add_node(node=node)
-        try:
-            executor.spin()
-        finally:
-            executor.shutdown()
-            node.destroy_node()
-            rclpy.shutdown()
+
+        node.new_thread.join()
     except KeyboardInterrupt:
         rclpy.logging.get_logger("clean_surface").info('interrupt received, so shutting down')
         

--- a/stretch_demos/stretch_demos/grasp_object.py
+++ b/stretch_demos/stretch_demos/grasp_object.py
@@ -34,10 +34,10 @@ import stretch_funmap.navigate as nv
 import stretch_funmap.manipulation_planning as mp
 
 
-class GraspObjectNode(Node):
+class GraspObjectNode(hm.HelloNode):
 
     def __init__(self):
-        super().__init__('grasp_node')
+        hm.HelloNode.__init__(self)
         self.rate = 10.0
         self.joint_states = None
         self.joint_states_lock = threading.Lock()
@@ -48,15 +48,6 @@ class GraspObjectNode(Node):
         self.lift_position = None
         self.manipulation_view = None
         self.debug_directory = None
-        self.tf2_buffer = tf2_ros.Buffer()
-        self.tf_listener = tf2_ros.transform_listener.TransformListener(self.tf2_buffer, self)
-        self.logger = self.get_logger()
-
-        self.move_to_pose_complete = False
-        self.unsuccessful_status = [-100, 100, FollowJointTrajectory.Result.PATH_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.INVALID_JOINTS, FollowJointTrajectory.Result.INVALID_GOAL, FollowJointTrajectory.Result.GOAL_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.OLD_HEADER_TIMESTAMP]
-        self._get_result_future = None
-
-        self.dryrun = False
         
     def joint_states_callback(self, joint_states):
         with self.joint_states_lock: 
@@ -67,16 +58,6 @@ class GraspObjectNode(Node):
         self.lift_position = lift_position
         self.left_finger_position, temp1, temp2 = hm.get_left_finger_state(joint_states)
 
-    def point_cloud_callback(self, point_cloud):
-        self.point_cloud = point_cloud
-
-    def tool_callback(self, tool_string):
-        self.tool = tool_string.data
-
-    def get_tool(self):
-        assert(self.tool is not None)
-        return self.tool
-
     def lower_tool_until_contact(self):
         if (self.dryrun):
             return
@@ -85,69 +66,6 @@ class GraspObjectNode(Node):
         trigger_request = Trigger.Request() 
         trigger_result = self.trigger_lower_until_contact_service.call_async(trigger_request)
         self.logger.info('trigger_result = {0}'.format(trigger_result))
-
-    def goal_response(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return False
-        goal_handle = future.result()
-        if not goal_handle.accepted:
-            self.move_to_pose_complete = True
-            return
-
-        self._get_result_future = goal_handle.get_result_async()
-
-    def get_result(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return
-
-        result = future.result().result
-        error_code = result.error_code
-        self.move_to_pose_complete = True
-
-    def move_to_pose(self, pose, return_before_done=False, custom_contact_thresholds=False):
-        if self.dryrun:
-            return None
-
-        self.move_to_pose_complete = False
-        joint_names = [key for key in pose]
-        point = JointTrajectoryPoint()
-        point.time_from_start = Duration(seconds=0.0).to_msg()
-
-        trajectory_goal = FollowJointTrajectory.Goal()
-        trajectory_goal.goal_time_tolerance = Duration(seconds=1.0).to_msg()
-        trajectory_goal.trajectory.joint_names = joint_names
-        if not custom_contact_thresholds: 
-            joint_positions = [pose[key] for key in joint_names]
-            point.positions = joint_positions
-            trajectory_goal.trajectory.points = [point]
-        else:
-            pose_correct = all([len(pose[key])==2 for key in joint_names])
-            if not pose_correct:
-                self.logger.error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
-                return
-            joint_positions = [pose[key][0] for key in joint_names]
-            joint_efforts = [pose[key][1] for key in joint_names]
-            point.positions = joint_positions
-            point.effort = joint_efforts
-            trajectory_goal.trajectory.points = [point]
-        trajectory_goal.trajectory.header.stamp = self.get_clock().now().to_msg()
-        self._send_goal_future = self.trajectory_client.send_goal_async(trajectory_goal)
-
-        if not return_before_done:
-            time_start = time.time()
-            self._get_result_future = None
-
-            while not self._get_result_future and (time.time() - time_start) < 10:
-                self.goal_response(self._send_goal_future)
-
-            if not self._get_result_future:
-                return self._send_goal_future
-
-            time_start = time.time()
-            while not self.move_to_pose_complete and (time.time() - time_start) < 10:
-                self.get_result(self._get_result_future)
-        
-        return self._send_goal_future
 
     def look_at_surface(self, scan_time_s=None):
         if self.dryrun:
@@ -183,13 +101,6 @@ class GraspObjectNode(Node):
             at_goal = self.move_base.forward(forward_m, detect_obstacles=False, tolerance_distance_m=tolerance_distance_m)
         else:
             at_goal = self.move_base.backward(forward_m, detect_obstacles=False, tolerance_distance_m=tolerance_distance_m)
-
-    def stow_the_robot(self):
-        if (self.dryrun):
-            return
-
-        trigger_request = Trigger.Request()
-        self._send_goal_future = self.stow_the_robot_service.call(trigger_request)
 
     def trigger_grasp_object_callback(self, request, response):
         max_lift_m = 1.09
@@ -236,7 +147,7 @@ class GraspObjectNode(Node):
         self.move_to_pose(pose)
 
         self.logger.info('Open the gripper.')
-        pose = {'gripper_aperture': 0.125}
+        pose = {'gripper_aperture': 0.07}
         self.move_to_pose(pose)
 
         pregrasp_mobile_base_m, pregrasp_wrist_extension_m = self.manipulation_view.get_pregrasp_planar_translation(grasp_target, self.tf2_buffer)
@@ -303,62 +214,42 @@ class GraspObjectNode(Node):
         )
     
     def main(self):
+        hm.HelloNode.main(self, 'grasp_object', 'grasp_object', wait_for_first_pointcloud=False)
+        self.logger = self.get_logger()
+
         self.callback_group = ReentrantCallbackGroup()
 
-        self.declare_parameter('debug_directory', '')
-        self.debug_directory = self.get_parameter('debug_directory').value
+        self.debug_directory = self.node.get_parameter('debug_directory').value
         self.logger.info('Using the following directory for debugging files: {0}'.format(self.debug_directory))
 
-        self.declare_parameter('dryrun', False)
-        self.dryrun = self.get_parameter('dryrun').value
+        self.dryrun = self.node.get_parameter('dryrun').value
 
-        self.joint_states_subscriber = self.create_subscription(JointState, '/stretch/joint_states', callback=self.joint_states_callback, qos_profile=1, callback_group=self.callback_group)
+        self.joint_states_subscriber = self.node.create_subscription(JointState, '/stretch/joint_states', callback=self.joint_states_callback, qos_profile=1, callback_group=self.callback_group)
 
-        self.point_cloud_subscriber = self.create_subscription(PointCloud2, '/camera/depth/color/points', callback=self.point_cloud_callback, qos_profile=1, callback_group=self.callback_group)
-
-        self.tool_subscriber = self.create_subscription(String, '/tool', callback=self.tool_callback, qos_profile=1, callback_group=self.callback_group)
-
-        self.trigger_grasp_object_service = self.create_service(Trigger,
+        self.trigger_grasp_object_service = self.node.create_service(Trigger,
                                                                 '/grasp_object/trigger_grasp_object',
                                                                 callback=self.trigger_grasp_object_callback,
                                                                 callback_group=self.callback_group)
 
-        self.trigger_reach_until_contact_service = self.create_client(Trigger, '/funmap/trigger_reach_until_contact', callback_group=self.callback_group)
+        self.trigger_reach_until_contact_service = self.node.create_client(Trigger, '/funmap/trigger_reach_until_contact', callback_group=self.callback_group)
         self.logger.info("Waiting for /funmap/trigger_reach_until_contact' service")
         self.trigger_reach_until_contact_service.wait_for_service()
-        self.logger.info('Node ' + self.get_name() + ' connected to /funmap/trigger_reach_until_contact.')
+        self.logger.info('Node ' + self.node.get_name() + ' connected to /funmap/trigger_reach_until_contact.')
 
 
-        self.trigger_lower_until_contact_service = self.create_client(Trigger, '/funmap/trigger_lower_until_contact', callback_group=self.callback_group)
+        self.trigger_lower_until_contact_service = self.node.create_client(Trigger, '/funmap/trigger_lower_until_contact', callback_group=self.callback_group)
         self.logger.info("Waiting for /funmap/trigger_lower_until_contact' service")
         self.trigger_lower_until_contact_service.wait_for_service()
-        self.logger.info('Node ' + self.get_name() + ' connected to /funmap/trigger_lower_until_contact.')
-
-        self.stow_the_robot_service = self.create_client(Trigger, '/stow_the_robot', callback_group=self.callback_group)
-        self.stow_the_robot_service.wait_for_service()
-        self.logger.info('Node ' + self.get_name() + ' connected to /stow_the_robot.')
-
-        self.trajectory_client = ActionClient(self, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory', callback_group=self.callback_group)
-        server_reached = self.trajectory_client.wait_for_server(timeout_sec=60.0)
-        if not server_reached:
-            self.get_logger().error('Unable to connect to joint_trajectory_server. Timeout exceeded.')
-            sys.exit()
+        self.logger.info('Node ' + self.node.get_name() + ' connected to /funmap/trigger_lower_until_contact.')
 
         self.logger.info("Grasp object node is ready!")
 
 def main():
     try:
-        rclpy.init()
         node = GraspObjectNode()
         node.main()
-        executor = MultiThreadedExecutor(num_threads=6)
-        executor.add_node(node=node)
-        try:
-            executor.spin()
-        finally:
-            executor.shutdown()
-            node.destroy_node()
-            rclpy.shutdown()
+        
+        node.new_thread.join()
     except KeyboardInterrupt:
         rclpy.logging.get_logger('grasp_object').info('interrupt received, so shutting down')
 

--- a/stretch_demos/stretch_demos/grasp_object.py
+++ b/stretch_demos/stretch_demos/grasp_object.py
@@ -1,31 +1,15 @@
 #!/usr/bin/env python3
 
 from sensor_msgs.msg import JointState
-from geometry_msgs.msg import Twist
-from nav_msgs.msg import Odometry
 
 import rclpy
-from rclpy.node import Node
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.action import ActionClient, ActionServer
-from rclpy.duration import Duration
-from rclpy.executors import MultiThreadedExecutor
 import rclpy.logging
-from rclpy.time import Time
 
-from control_msgs.action import FollowJointTrajectory
-from trajectory_msgs.msg import JointTrajectoryPoint
-
-from sensor_msgs.msg import PointCloud2
-from std_msgs.msg import String
 from std_srvs.srv import Trigger
 
-import math
 import time
 import threading
-import sys
-import tf2_ros
-import argparse as ap        
 import numpy as np
 import os
 

--- a/stretch_demos/stretch_demos/grasp_object.py
+++ b/stretch_demos/stretch_demos/grasp_object.py
@@ -219,28 +219,28 @@ class GraspObjectNode(hm.HelloNode):
 
         self.callback_group = ReentrantCallbackGroup()
 
-        self.debug_directory = self.node.get_parameter('debug_directory').value
+        self.debug_directory = self.get_parameter('debug_directory').value
         self.logger.info('Using the following directory for debugging files: {0}'.format(self.debug_directory))
 
-        self.dryrun = self.node.get_parameter('dryrun').value
+        self.dryrun = self.get_parameter('dryrun').value
 
-        self.joint_states_subscriber = self.node.create_subscription(JointState, '/stretch/joint_states', callback=self.joint_states_callback, qos_profile=1, callback_group=self.callback_group)
+        self.joint_states_subscriber = self.create_subscription(JointState, '/stretch/joint_states', callback=self.joint_states_callback, qos_profile=1, callback_group=self.callback_group)
 
-        self.trigger_grasp_object_service = self.node.create_service(Trigger,
+        self.trigger_grasp_object_service = self.create_service(Trigger,
                                                                 '/grasp_object/trigger_grasp_object',
                                                                 callback=self.trigger_grasp_object_callback,
                                                                 callback_group=self.callback_group)
 
-        self.trigger_reach_until_contact_service = self.node.create_client(Trigger, '/funmap/trigger_reach_until_contact', callback_group=self.callback_group)
+        self.trigger_reach_until_contact_service = self.create_client(Trigger, '/funmap/trigger_reach_until_contact', callback_group=self.callback_group)
         self.logger.info("Waiting for /funmap/trigger_reach_until_contact' service")
         self.trigger_reach_until_contact_service.wait_for_service()
-        self.logger.info('Node ' + self.node.get_name() + ' connected to /funmap/trigger_reach_until_contact.')
+        self.logger.info('Node ' + self.get_name() + ' connected to /funmap/trigger_reach_until_contact.')
 
 
-        self.trigger_lower_until_contact_service = self.node.create_client(Trigger, '/funmap/trigger_lower_until_contact', callback_group=self.callback_group)
+        self.trigger_lower_until_contact_service = self.create_client(Trigger, '/funmap/trigger_lower_until_contact', callback_group=self.callback_group)
         self.logger.info("Waiting for /funmap/trigger_lower_until_contact' service")
         self.trigger_lower_until_contact_service.wait_for_service()
-        self.logger.info('Node ' + self.node.get_name() + ' connected to /funmap/trigger_lower_until_contact.')
+        self.logger.info('Node ' + self.get_name() + ' connected to /funmap/trigger_lower_until_contact.')
 
         self.logger.info("Grasp object node is ready!")
 

--- a/stretch_demos/stretch_demos/hello_world.py
+++ b/stretch_demos/stretch_demos/hello_world.py
@@ -1,121 +1,39 @@
 #!/usr/bin/env python3
 
-from sensor_msgs.msg import JointState
-from geometry_msgs.msg import Twist
-from nav_msgs.msg import Odometry
-
 import rclpy
-from rclpy.action import ActionClient, ActionServer
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.duration import Duration
-from rclpy.executors import MultiThreadedExecutor
 import rclpy.logging
-from rclpy.node import Node
-from rclpy.time import Time
 
-from control_msgs.action import FollowJointTrajectory
-from trajectory_msgs.msg import JointTrajectoryPoint
-from sensor_msgs.msg import PointCloud2
+from sensor_msgs.msg import JointState
 from std_srvs.srv import Trigger
 
-import math
 import time
 import threading
-import sys
-import tf2_ros
-import argparse as ap        
 
 import hello_helpers.hello_misc as hm
 import stretch_funmap.navigate as nv
 
 
-class HelloWorldNode(Node):
+class HelloWorldNode(hm.HelloNode):
 
     def __init__(self):
-        super().__init__('hello_world')
+        hm.HelloNode.__init__(self)
         self.rate = 10.0
         self.joint_states = None
         self.joint_states_lock = threading.Lock()
         self.move_base = nv.MoveBase(self)
         self.letter_height_m = 0.2
         self.letter_top_lift_m = 1.08
-        self.logger = self.get_logger()
-        self.tf2_buffer = tf2_ros.Buffer()
-        self.tf_listener = tf2_ros.transform_listener.TransformListener(self.tf2_buffer, self)
-        self.move_to_pose_complete = False
-        self.unsuccessful_status = [-100, 100, FollowJointTrajectory.Result.PATH_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.INVALID_JOINTS, FollowJointTrajectory.Result.INVALID_GOAL, FollowJointTrajectory.Result.GOAL_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.OLD_HEADER_TIMESTAMP]
-        self._get_result_future = None
         
     def joint_states_callback(self, joint_states):
         with self.joint_states_lock: 
             self.joint_states = joint_states
-
-    def goal_response(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return False
-        goal_handle = future.result()
-        if not goal_handle.accepted:
-            self.move_to_pose_complete = True
-            return
-
-        self._get_result_future = goal_handle.get_result_async()
-
-    def get_result(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return
-
-        result = future.result().result
-        error_code = result.error_code
-        self.move_to_pose_complete = True
-    
-    def move_to_pose(self, pose, return_before_done=False, custom_contact_thresholds=False):
-        self.move_to_pose_complete = False
-        joint_names = [key for key in pose]
-        point = JointTrajectoryPoint()
-        point.time_from_start = Duration(seconds=0.0).to_msg()
-
-        trajectory_goal = FollowJointTrajectory.Goal()
-        trajectory_goal.goal_time_tolerance = Duration(seconds=1.0).to_msg()
-        trajectory_goal.trajectory.joint_names = joint_names
-        if not custom_contact_thresholds: 
-            joint_positions = [pose[key] for key in joint_names]
-            point.positions = joint_positions
-            trajectory_goal.trajectory.points = [point]
-        else:
-            pose_correct = all([len(pose[key])==2 for key in joint_names])
-            if not pose_correct:
-                self.logger.error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
-                return
-            joint_positions = [pose[key][0] for key in joint_names]
-            joint_efforts = [pose[key][1] for key in joint_names]
-            point.positions = joint_positions
-            point.effort = joint_efforts
-            trajectory_goal.trajectory.points = [point]
-        trajectory_goal.trajectory.header.stamp = self.get_clock().now().to_msg()
-        self._send_goal_future = self.trajectory_client.send_goal_async(trajectory_goal)
-
-        if not return_before_done:
-            time_start = time.time()
-            self._get_result_future = None
-
-            while self._get_result_future == None and (time.time() - time_start) < 10:
-                self.goal_response(self._send_goal_future)
-
-            if self._get_result_future == None:
-                return self._send_goal_future
-
-            time_start = time.time()
-            while not self.move_to_pose_complete and (time.time() - time_start) < 10:
-                self.get_result(self._get_result_future)
-        
-        return self._send_goal_future
 
     def align_to_surface(self):
         self.logger.info('align_to_surface')
         trigger_request = Trigger.Request() 
         trigger_result = self.trigger_align_with_nearest_cliff_service.call_async(trigger_request)
         self.logger.info('trigger_result = {0}'.format(trigger_result))
-
 
     def backoff_after_contact(self):
         self.logger.info('backoff after contact')
@@ -157,7 +75,6 @@ class HelloWorldNode(Node):
         self.move_to_pose(pose, custom_contact_thresholds=True)
         time.sleep(1.0) # Give it time to backoff before the next move. Otherwise it may not backoff.
 
-        
     def vertical_line(self, move_down, half=False):
         if move_down: 
             self.logger.info('vertical_line moving down')
@@ -204,7 +121,6 @@ class HelloWorldNode(Node):
         self.align_to_surface()
         self.horizontal_line(move_right=True, half=True)
 
-
     def move_arm_out_of_the_way(self):
         initial_pose = {'wrist_extension': 0.01,
                         'joint_lift': 0.8,
@@ -212,7 +128,6 @@ class HelloWorldNode(Node):
 
         self.logger.info('Move arm out of the way of the camera.')
         self.move_to_pose(initial_pose)
-
         
     def move_to_initial_configuration(self):
         initial_pose = {'wrist_extension': 0.01,
@@ -313,8 +228,10 @@ class HelloWorldNode(Node):
             message='Completed writing hello!'
             )
 
-    
     def main(self):
+        hm.HelloNode.main(self, 'hello_world', 'hello_world', wait_for_first_pointcloud=False)
+
+        self.logger = self.get_logger()
         self.callback_group = ReentrantCallbackGroup()
 
         self.joint_states_subscriber = self.create_subscription(JointState, '/stretch/joint_states', callback=self.joint_states_callback, qos_profile=1, callback_group=self.callback_group)
@@ -330,20 +247,12 @@ class HelloWorldNode(Node):
         self.trigger_reach_until_contact_service.wait_for_service()
         self.logger.info('Node ' + self.get_name() + ' connected to /funmap/trigger_reach_until_contact.')
 
-        self.trajectory_client = ActionClient(self, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory', callback_group=self.callback_group)
-        server_reached = self.trajectory_client.wait_for_server(timeout_sec=60.0)
-        if not server_reached:
-            self.get_logger().error('Unable to connect to joint_trajectory_server. Timeout exceeded.')
-            sys.exit()
-
 def main():
     try:
-        rclpy.init()
         node = HelloWorldNode()
         node.main()
-        executor = MultiThreadedExecutor(num_threads=6)
-        executor.add_node(node=node)
-        executor.spin()
+
+        node.new_thread.join()
     except KeyboardInterrupt:
         rclpy.logging.get_logger('hello_world').info('interrupt received, so shutting down')
 

--- a/stretch_demos/stretch_demos/open_drawer.py
+++ b/stretch_demos/stretch_demos/open_drawer.py
@@ -1,52 +1,28 @@
 #!/usr/bin/env python3
 
-from sensor_msgs.msg import JointState
-from geometry_msgs.msg import Twist
-from nav_msgs.msg import Odometry
-
 import rclpy
-from rclpy.action import ActionClient, ActionServer
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.duration import Duration
-from rclpy.executors import MultiThreadedExecutor
 import rclpy.logging
-from rclpy.node import Node
-from rclpy.time import Time
 
-from control_msgs.action import FollowJointTrajectory
-from trajectory_msgs.msg import JointTrajectoryPoint
-from sensor_msgs.msg import PointCloud2
-
+from sensor_msgs.msg import JointState
 from std_srvs.srv import Trigger
 
-import math
 import time
 import threading
-import sys
-
-import tf2_ros
-import argparse as ap
 
 import hello_helpers.hello_misc as hm
 import stretch_funmap.navigate as nv
 
-class OpenDrawerNode(Node):
+class OpenDrawerNode(hm.HelloNode):
 
     def __init__(self):
-        super().__init__('open_drawer')
+        hm.HelloNode.__init__(self)
         self.rate = 10.0
         self.joint_states = None
         self.joint_states_lock = threading.Lock()
         self.move_base = nv.MoveBase(self)
-        self.letter_height_m = 0.2
         self.wrist_position = None
         self.lift_position = None
-        self.logger = rclpy.logging.get_logger('open_drawer')
-        self.tf2_buffer = tf2_ros.Buffer()
-        self.tf_listener = tf2_ros.transform_listener.TransformListener(self.tf2_buffer, self)
-        self.move_to_pose_complete = False
-        self.unsuccessful_status = [-100, 100, FollowJointTrajectory.Result.PATH_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.INVALID_JOINTS, FollowJointTrajectory.Result.INVALID_GOAL, FollowJointTrajectory.Result.GOAL_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.OLD_HEADER_TIMESTAMP]
-        self._get_result_future = None
 
     def joint_states_callback(self, joint_states):
         with self.joint_states_lock:
@@ -55,72 +31,6 @@ class OpenDrawerNode(Node):
         self.wrist_position = wrist_position
         lift_position, lift_velocity, lift_effort = hm.get_lift_state(joint_states)
         self.lift_position = lift_position
-    
-    def goal_response(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return False
-        goal_handle = future.result()
-        if not goal_handle.accepted:
-            self.move_to_pose_complete = True
-            return
-
-        self._get_result_future = goal_handle.get_result_async()
-
-    def get_result(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return
-
-        result = future.result().result
-        error_code = result.error_code
-        self.move_to_pose_complete = True
-
-    def move_to_pose(self, pose, return_before_done=False, custom_contact_thresholds=False):
-        self.move_to_pose_complete = False
-        joint_names = [key for key in pose]
-        point = JointTrajectoryPoint()
-        point.time_from_start = Duration(seconds=0.0).to_msg()
-
-        trajectory_goal = FollowJointTrajectory.Goal()
-        trajectory_goal.goal_time_tolerance = Duration(seconds=1.0).to_msg()
-        trajectory_goal.trajectory.joint_names = joint_names
-        if not custom_contact_thresholds: 
-            joint_positions = [pose[key] for key in joint_names]
-            point.positions = joint_positions
-            trajectory_goal.trajectory.points = [point]
-        else:
-            pose_correct = all([len(pose[key])==2 for key in joint_names])
-            if not pose_correct:
-                self.logger.error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
-                return
-            joint_positions = [pose[key][0] for key in joint_names]
-            joint_efforts = [pose[key][1] for key in joint_names]
-            point.positions = joint_positions
-            point.effort = joint_efforts
-            trajectory_goal.trajectory.points = [point]
-        trajectory_goal.trajectory.header.stamp = self.get_clock().now().to_msg()
-        self._send_goal_future = self.trajectory_client.send_goal_async(trajectory_goal)
-
-        if not return_before_done:
-            time_start = time.time()
-            self._get_result_future = None
-
-            while not self._get_result_future and (time.time() - time_start) < 10:
-                self.goal_response(self._send_goal_future)
-
-            if not self._get_result_future:
-                return self._send_goal_future
-
-            time_start = time.time()
-            while not self.move_to_pose_complete and (time.time() - time_start) < 10:
-                self.get_result(self._get_result_future)
-        
-        return self._send_goal_future
-
-    def align_to_surface(self):
-        self.logger.info('align_to_surface')
-        trigger_request = Trigger.Request()
-        trigger_result = self.trigger_align_with_nearest_cliff_service.call_async(trigger_request)
-        self.logger.info('trigger_result = {0}'.format(trigger_result))
 
     def extend_hook_until_contact(self):
         self.logger.info('extend_hook_until_contact')
@@ -252,25 +162,18 @@ class OpenDrawerNode(Node):
 
 
     def main(self):
+        hm.HelloNode.main(self, 'open_drawer', 'open_drawer', wait_for_first_pointcloud=False)
+        
+        self.logger = self.get_logger()
         self.callback_group = ReentrantCallbackGroup()
 
         self.joint_states_subscriber = self.create_subscription(JointState, '/stretch/joint_states', self.joint_states_callback, qos_profile=1, callback_group=self.callback_group)
-
-        self.trajectory_client = ActionClient(self, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory', callback_group=self.callback_group)
-        server_reached = self.trajectory_client.wait_for_server(timeout_sec=60.0)
-        if not server_reached:
-            self.get_logger().error('Unable to connect to joint_trajectory_server. Timeout exceeded.')
-            sys.exit()
 
         self.trigger_open_drawer_service = self.create_service(Trigger, '/open_drawer/trigger_open_drawer_down',
                                                          self.trigger_open_drawer_down_callback, callback_group=self.callback_group)
 
         self.trigger_open_drawer_service = self.create_service(Trigger, '/open_drawer/trigger_open_drawer_up',
                                                          self.trigger_open_drawer_up_callback, callback_group=self.callback_group)
-
-        self.trigger_align_with_nearest_cliff_service = self.create_client(Trigger, '/funmap/trigger_align_with_nearest_cliff', callback_group=self.callback_group)
-        self.trigger_align_with_nearest_cliff_service.wait_for_service()
-        self.logger.info('Node ' + self.get_name() + ' connected to /funmap/trigger_align_with_nearest_cliff.')
 
         self.trigger_reach_until_contact_service = self.create_client(Trigger, '/funmap/trigger_reach_until_contact', callback_group=self.callback_group)
         self.trigger_reach_until_contact_service.wait_for_service()
@@ -282,18 +185,11 @@ class OpenDrawerNode(Node):
 
 
 def main():
-    rclpy.init()
     try:
         node = OpenDrawerNode()
         node.main()
-        executor = MultiThreadedExecutor(num_threads=6)
-        executor.add_node(node=node)
-        try:
-            executor.spin()
-        finally:
-            executor.shutdown()
-            node.destroy_node()
-            rclpy.shutdown()
+
+        node.new_thread.join()
     except KeyboardInterrupt:
         rclpy.logging.get_logger('open_drawer').info('interrupt received, so shutting down')
 

--- a/stretch_funmap/launch/funmap.launch.py
+++ b/stretch_funmap/launch/funmap.launch.py
@@ -1,9 +1,5 @@
-import os
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, LogInfo
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.conditions import LaunchConfigurationEquals
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 

--- a/stretch_funmap/launch/mapping.launch.py
+++ b/stretch_funmap/launch/mapping.launch.py
@@ -1,9 +1,8 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, LogInfo
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.conditions import LaunchConfigurationEquals
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 

--- a/stretch_funmap/stretch_funmap/funmap.py
+++ b/stretch_funmap/stretch_funmap/funmap.py
@@ -1,20 +1,15 @@
 #!/usr/bin/env python3
 
 import rclpy
-from rclpy.action import ActionClient, ActionServer
-from rclpy.callback_groups import ReentrantCallbackGroup, MutuallyExclusiveCallbackGroup
+from rclpy.action import ActionServer
+from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.client import Client
-from rclpy.clock import Clock
 from rclpy.duration import Duration
-from rclpy.executors import MultiThreadedExecutor
 import rclpy.logging
-from rclpy.node import Node
 import rclpy.task
 from rclpy.time import Time
 
-from control_msgs.action import FollowJointTrajectory
-from geometry_msgs.msg import Transform, TransformStamped, PoseWithCovarianceStamped, PoseStamped, Pose, PointStamped
-from nav_msgs.msg import Odometry
+from geometry_msgs.msg import Transform, TransformStamped, PoseWithCovarianceStamped, PoseStamped, PointStamped
 from nav_msgs.srv import GetPlan
 from nav_msgs.msg import Path
 from nav2_msgs.action import NavigateToPose
@@ -24,16 +19,12 @@ from std_srvs.srv import Trigger
 from tf_transformations import euler_from_quaternion
 from tf2_geometry_msgs import do_transform_pose
 import tf2_ros
-from trajectory_msgs.msg import JointTrajectoryPoint
 from visualization_msgs.msg import Marker, MarkerArray
 
 import hello_helpers.hello_misc as hm
 import hello_helpers.hello_ros_viz as hr
 
-import copy
-import math
 import os
-import sys
 import threading
 import time
 

--- a/stretch_funmap/stretch_funmap/funmap.py
+++ b/stretch_funmap/stretch_funmap/funmap.py
@@ -1408,7 +1408,6 @@ class FunmapNode(hm.HelloNode):
 
 def main():
     try:
-        rclpy.init()
         node = FunmapNode()
         node.main()
     except KeyboardInterrupt:

--- a/stretch_funmap/stretch_funmap/funmap.py
+++ b/stretch_funmap/stretch_funmap/funmap.py
@@ -193,7 +193,7 @@ class ContactDetector():
                 if position is not None:
                     new_target = self.get_position() + move_increment
                     pose = {joint_name: new_target}
-                    move_to_pose(pose, return_before_done=True)
+                    move_to_pose(pose, blocking=False)
                 time.sleep(0.2)
 
             if self.is_in_contact():
@@ -205,7 +205,7 @@ class ContactDetector():
                 else:
                     new_target = self.get_position() - 0.001  # - 0.002
                 pose = {joint_name: new_target}
-                move_to_pose(pose, return_before_done=False)
+                move_to_pose(pose, blocking=True)
                 self.logger.info(
                     'backing off after contact: moving away from surface to decrease force')
                 success = True
@@ -219,10 +219,10 @@ class ContactDetector():
         return success, message
 
 
-class FunmapNode(Node):
+class FunmapNode(hm.HelloNode):
 
     def __init__(self):
-        super().__init__('stretch_funmap')
+        hm.HelloNode.__init__(self)
 
         self.map_filename = None
         self.debug_directory = None
@@ -243,12 +243,6 @@ class FunmapNode(Node):
         self.wrist_position = None
 
         self.use_hook = False  # True #False
-
-        self.logger = self.get_logger()
-        self.clock = self.get_clock()
-        self.move_to_pose_complete = False
-        self.unsuccessful_status = [-100, 100, FollowJointTrajectory.Result.PATH_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.INVALID_JOINTS, FollowJointTrajectory.Result.INVALID_GOAL, FollowJointTrajectory.Result.GOAL_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.OLD_HEADER_TIMESTAMP]
-        self._get_result_future = None
 
         self.point_cloud_lock = threading.Lock()
         self.map_odom_tf_lock = threading.Lock()
@@ -469,7 +463,7 @@ class FunmapNode(Node):
                     safe_target_m = safe_target_m + 0.03
                 if safe_target_m > self.wrist_position:
                     pose = {'wrist_extension': safe_target_m}
-                    self.move_to_pose(pose, return_before_done=False)
+                    self.move_to_pose(pose, blocking=True)
 
                 # target depth within the surface
                 target_depth_m = 0.08
@@ -1289,100 +1283,6 @@ class FunmapNode(Node):
             self.logger.error(message)
         return result
 
-    def goal_response(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            # self.logger.info("Future goal result is not set")
-            return False
-        goal_handle = future.result()
-        if not goal_handle.accepted:
-            self.move_to_pose_complete = True
-            return
-
-        self._get_result_future = goal_handle.get_result_async()
-
-    def get_result(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return
-
-        result = future.result().result
-        error_code = result.error_code
-        # self.logger.info('The Action Server has finished, it returned: "%s"' % str(error_code))
-        self.move_to_pose_complete = True
-    
-    def move_to_pose(self, pose, return_before_done=False, custom_contact_thresholds=False):
-        self.move_to_pose_complete = False
-        joint_names = [key for key in pose]
-        point = JointTrajectoryPoint()
-        point.time_from_start = Duration(seconds=0.0).to_msg()
-
-        trajectory_goal = FollowJointTrajectory.Goal()
-        trajectory_goal.goal_time_tolerance = Duration(seconds=1.0).to_msg()
-        trajectory_goal.trajectory.joint_names = joint_names
-        if not custom_contact_thresholds: 
-            joint_positions = [pose[key] for key in joint_names]
-            point.positions = joint_positions
-            trajectory_goal.trajectory.points = [point]
-        else:
-            pose_correct = all([len(pose[key])==2 for key in joint_names])
-            if not pose_correct:
-                self.logger.error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
-                return
-            joint_positions = [pose[key][0] for key in joint_names]
-            joint_efforts = [pose[key][1] for key in joint_names]
-            point.positions = joint_positions
-            point.effort = joint_efforts
-            trajectory_goal.trajectory.points = [point]
-        trajectory_goal.trajectory.header.stamp = self.get_clock().now().to_msg()
-        self._send_goal_future = self.trajectory_client.send_goal_async(trajectory_goal)
-
-        if not return_before_done:
-            time_start = time.time()
-            self._get_result_future = None
-
-            while not self._get_result_future and (time.time() - time_start) < 10:
-                self.goal_response(self._send_goal_future)
-
-            if not self._get_result_future:
-                return self._send_goal_future
-
-            time_start = time.time()
-            while not self.move_to_pose_complete and (time.time() - time_start) < 10:
-                self.get_result(self._get_result_future)
-        
-        return self._send_goal_future
-
-    def get_robot_floor_pose_xya(self, floor_frame='odom'):
-        # Returns the current estimated x, y position and angle of the
-        # robot on the floor. This is typically called with respect to
-        # the odom frame or the map frame. x and y are in meters and
-        # the angle is in radians.
-        
-        # Navigation planning is performed with respect to a height of
-        # 0.0, so the heights of transformed points are 0.0. The
-        # simple method of handling the heights below assumes that the
-        # frame is aligned such that the z axis is normal to the
-        # floor, so that ignoring the z coordinate is approximately
-        # equivalent to projecting a point onto the floor.
-        
-        # Query TF2 to obtain the current estimated transformation
-        # from the robot's base_link frame to the frame.
-        robot_to_odom_mat, timestamp = hm.get_p1_to_p2_matrix('base_link', floor_frame, self.tf2_buffer)
-        print('robot_to_odom_mat =', robot_to_odom_mat)
-        print('timestamp =', timestamp)
-
-        # Find the robot's current location in the frame.
-        r0 = np.array([0.0, 0.0, 0.0, 1.0])
-        print('r0 =', r0)
-        r0 = np.matmul(robot_to_odom_mat, r0)[:2]
-
-        # Find the current angle of the robot in the frame.
-        r1 = np.array([1.0, 0.0, 0.0, 1.0])
-        r1 = np.matmul(robot_to_odom_mat, r1)[:2]
-        robot_forward = r1 - r0
-        r_ang = np.arctan2(robot_forward[1], robot_forward[0])
-
-        return [r0[0], r0[1], r_ang], timestamp
-
     def publish_map_to_odom_tf(self):
         while rclpy.ok():
             with self.map_odom_tf_lock:
@@ -1391,10 +1291,13 @@ class FunmapNode(Node):
                 time.sleep(0.2)
 
     def main(self):
-        self.declare_parameter('debug_directory', '')
+        hm.HelloNode.main(self, 'funmap', 'funmap')
+        
+        self.logger = self.get_logger()
+        self.clock = self.get_clock()
+        
         self.debug_directory = self.get_parameter('debug_directory').value
 
-        self.declare_parameter('map_yaml', '')
         self.map_filename = self.get_parameter('map_yaml').value
 
         self.merged_map = None
@@ -1485,45 +1388,12 @@ class FunmapNode(Node):
             JointState, '/stretch/joint_states', self.joint_states_callback, 1, callback_group=self.callback_group)
 
         self.move_base = nv.MoveBase(self, self.debug_directory)
-        
-        self.trajectory_client = ActionClient(self, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory')
-        server_reached = self.trajectory_client.wait_for_server(timeout_sec=60.0)
-        if not server_reached:
-            self.logger.error('Unable to connect to arm action server. Timeout exceeded.')
-            sys.exit()
-
-        self.tf2_buffer = tf2_ros.Buffer()
-        self.tf2_listener = tf2_ros.TransformListener(self.tf2_buffer, self)
-
-        self.point_cloud_subscriber = self.create_subscription(PointCloud2, '/camera/depth/color/points', self.point_cloud_callback, 1, callback_group=self.callback_group)
-        # self.point_cloud_pub = self.create_publisher(PointCloud2, '/funmap/point_cloud2', 1)
-
-        self.stop_the_robot_service = self.create_client(Trigger, '/stop_the_robot', callback_group=self.callback_group)
-        while not self.stop_the_robot_service.wait_for_service(timeout_sec=2.0):
-            self.get_logger().info("Waiting on '/stop_the_robot' service...")
-        self.logger.info('Node ' + self.get_name() + ' connected to /stop_the_robot service.')
 
         hz = 5.0
         self.rate = self.create_rate(hz, self.get_clock())
 
-        # Do not start until a point cloud has been received
-        with self.point_cloud_lock:
-            point_cloud_msg = self.point_cloud
-        self.get_logger().info('Node ' + self.get_name() + ' waiting to receive first point cloud.')
-        while point_cloud_msg is None:
-            # self.rate.sleep()
-            time.sleep(0.2)
-            # self.get_logger().info("Spinning...")
-            rclpy.spin_once(self)
-            with self.point_cloud_lock:
-                point_cloud_msg = self.point_cloud
-        self.get_logger().info('Node ' + self.get_name() + ' received first point cloud, so continuing.')
-
         with self.map_odom_tf_lock:
             self.map_to_odom_transform_mat = np.identity(4)
-
-        executor = MultiThreadedExecutor(num_threads=6)
-        executor.add_node(self)
 
         self.map_odom_tf_thread = threading.Thread(target=self.publish_map_to_odom_tf)
         self.map_odom_tf_thread.start()
@@ -1531,7 +1401,7 @@ class FunmapNode(Node):
         self.publish_map_point_cloud_thread = threading.Thread(target=self.publish_map_point_cloud)
         self.publish_map_point_cloud_thread.start()
 
-        executor.spin()
+        self.new_thread.join()
 
         self.map_odom_tf_thread.join()
         self.publish_map_point_cloud_thread.join()

--- a/stretch_funmap/stretch_funmap/manipulation_planning.py
+++ b/stretch_funmap/stretch_funmap/manipulation_planning.py
@@ -8,7 +8,6 @@ from rclpy.time import Time
 import hello_helpers.hello_misc as hm
 import ros2_numpy as rn
 
-import math
 import os
 import time
 
@@ -18,7 +17,6 @@ import scipy.ndimage as nd
 import scipy.signal as si
 import skimage as sk
 
-from . import max_height_image as mh
 from .numba_manipulation_planning import numba_find_base_poses_that_reach_target, numba_check_that_tool_can_deploy
 from .numba_check_line_path import numba_find_contact_along_line_path, numba_find_line_path_on_surface
 from . import ros_max_height_image as rm

--- a/stretch_funmap/stretch_funmap/mapping.py
+++ b/stretch_funmap/stretch_funmap/mapping.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
 
-import rclpy
-from rclpy.clock import Clock
-from rclpy.duration import Duration
-import rclpy.logging
-import rclpy.time
-
 from builtin_interfaces.msg import Time
 import ros2_numpy as rn
 import tf_transformations
@@ -21,9 +15,7 @@ import numpy as np
 import scipy.ndimage as nd
 
 from . import merge_maps as mm
-from . import navigation_planning as na
 from . import ros_max_height_image as rm
-from . import segment_max_height_image as sm
 
 def stow_and_lower_arm(node):
     pose = {'joint_gripper_finger_left': -0.15}

--- a/stretch_funmap/stretch_funmap/max_height_image.py
+++ b/stretch_funmap/stretch_funmap/max_height_image.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 
-from collections import deque
 from copy import deepcopy
 import gzip
-import math
-import struct
-import sys
-import threading
 import yaml
 
 import cv2
 import numpy as np
-from scipy.spatial.transform import Rotation
 
 from . import numba_height_image as nh
-from .numba_create_plane_image import numba_create_plane_image, numba_correct_height_image, transform_original_to_corrected, transform_corrected_to_original
+from .numba_create_plane_image import numba_correct_height_image
 
 class Colormap:
     def __init__(self, colormap=cv2.COLORMAP_HSV):

--- a/stretch_funmap/stretch_funmap/merge_maps.py
+++ b/stretch_funmap/stretch_funmap/merge_maps.py
@@ -2,22 +2,10 @@
 
 import tf_transformations
 
-import hello_helpers.hello_misc as hm
-
-import copy
 import cv2
-import math
-import time
 
 import cma
 import numpy as np
-from scipy.optimize import minimize, minimize_scalar
-import scipy.ndimage as nd
-import scipy.signal as si
-
-from . import mapping as ma
-from . import max_height_image as mh
-from . import navigation_planning as na
 from .numba_compare_images import numba_compare_images_2
 
 def affine_transform_2d_point(affine_matrix, point):

--- a/stretch_funmap/stretch_funmap/navigate.py
+++ b/stretch_funmap/stretch_funmap/navigate.py
@@ -320,7 +320,7 @@ class MoveBase():
             pose = {'translate_mobile_base': forward_distance_m}
             self.at_goal = False
             self.unsuccessful_action = False
-            self._future_goal = self.node.move_to_pose(pose, return_before_done=True)
+            self._future_goal = self.node.move_to_pose(pose, blocking=False)
 
             # Check if goal has been successfully sent to the joint trajectory server
             pose_sent = False
@@ -384,7 +384,7 @@ class MoveBase():
             pose = {'rotate_mobile_base': turn_angle_error_rad}
             self.at_goal = False
             self.unsuccessful_action = False
-            self._future_goal = self.node.move_to_pose(pose, return_before_done=True)
+            self._future_goal = self.node.move_to_pose(pose, blocking=False)
 
             # Check if goal has been successfully sent to the joint trajectory server
             pose_sent = False

--- a/stretch_funmap/stretch_funmap/navigate.py
+++ b/stretch_funmap/stretch_funmap/navigate.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import rclpy
-from rclpy.duration import Duration
-from rclpy.clock import Clock, ClockType
 import rclpy.logging
 import rclpy.task
 
@@ -12,7 +10,6 @@ from std_srvs.srv import Trigger
 
 import hello_helpers.hello_misc as hm
 
-from functools import partial
 import os
 import time
 

--- a/stretch_funmap/stretch_funmap/navigation_planning.py
+++ b/stretch_funmap/stretch_funmap/navigation_planning.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
 
-import hello_helpers.hello_misc as hm
-
-import copy
-
 import cv2
 import numpy as np
 import scipy.ndimage as nd

--- a/stretch_funmap/stretch_funmap/ros_max_height_image.py
+++ b/stretch_funmap/stretch_funmap/ros_max_height_image.py
@@ -5,22 +5,11 @@ from rclpy.duration import Duration
 import rclpy.logging
 from rclpy.time import Time
 
-from geometry_msgs.msg import Transform, Pose, Vector3, Quaternion, Point
-from nav_msgs.msg import OccupancyGrid, MapMetaData
 import ros2_numpy
 from sensor_msgs.msg import PointCloud2
-from std_msgs.msg import Header
 import tf2_ros
-from visualization_msgs.msg import Marker, MarkerArray
+from visualization_msgs.msg import Marker
 
-from collections import deque
-from copy import deepcopy
-import math
-import struct
-import sys
-import threading
-
-import cv2
 import numpy as np
 from scipy.spatial.transform import Rotation
 

--- a/stretch_funmap/stretch_funmap/segment_max_height_image.py
+++ b/stretch_funmap/stretch_funmap/segment_max_height_image.py
@@ -12,7 +12,6 @@ import scipy.signal as si
 import skimage as sk
 from skimage.morphology import convex_hull_image
 
-from . import max_height_image as mh
 from . import navigation_planning as na
 from .numba_height_image import numba_create_segment_image_uint8
 


### PR DESCRIPTION
This PR makes several changes to the stretch_demos package:
1. Updates HelloNode class by creating node through the Node class - previously done with rclpy.create_node method
2. Updates all demos to subclass from the HelloNode class to remove repetitive code
3. Updates the grasp object demo to work with a DexWrist
4. Adds instructions to run keyboard teleop in a separate terminal for each demo

To test, follow instructions in the README

Bugs that require further investigation:
1. Plane detection in the clean surface demo is poor because of poor fill rate from RealSense. The pointcloud feed in the realsense-viewer has a much better fill rate than one generated by the ROS drivers.
2. The open drawer demo applies too much effort when descending the hook to grab the drawer handle. This is because of the contact threshold bug in the lift. See https://github.com/hello-robot/stretch_firmware/pull/22