### PR TITLE
Update FUNMAP with HelloNode

### DIFF
--- a/stretch_funmap/launch/funmap.launch.py
+++ b/stretch_funmap/launch/funmap.launch.py
@@ -1,9 +1,5 @@
-import os
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, LogInfo
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.conditions import LaunchConfigurationEquals
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 

--- a/stretch_funmap/launch/mapping.launch.py
+++ b/stretch_funmap/launch/mapping.launch.py
@@ -1,9 +1,8 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, LogInfo
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.conditions import LaunchConfigurationEquals
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 

--- a/stretch_funmap/stretch_funmap/funmap.py
+++ b/stretch_funmap/stretch_funmap/funmap.py
@@ -1,20 +1,15 @@
 #!/usr/bin/env python3
 
 import rclpy
-from rclpy.action import ActionClient, ActionServer
-from rclpy.callback_groups import ReentrantCallbackGroup, MutuallyExclusiveCallbackGroup
+from rclpy.action import ActionServer
+from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.client import Client
-from rclpy.clock import Clock
 from rclpy.duration import Duration
-from rclpy.executors import MultiThreadedExecutor
 import rclpy.logging
-from rclpy.node import Node
 import rclpy.task
 from rclpy.time import Time
 
-from control_msgs.action import FollowJointTrajectory
-from geometry_msgs.msg import Transform, TransformStamped, PoseWithCovarianceStamped, PoseStamped, Pose, PointStamped
-from nav_msgs.msg import Odometry
+from geometry_msgs.msg import Transform, TransformStamped, PoseWithCovarianceStamped, PoseStamped, PointStamped
 from nav_msgs.srv import GetPlan
 from nav_msgs.msg import Path
 from nav2_msgs.action import NavigateToPose
@@ -24,16 +19,12 @@ from std_srvs.srv import Trigger
 from tf_transformations import euler_from_quaternion
 from tf2_geometry_msgs import do_transform_pose
 import tf2_ros
-from trajectory_msgs.msg import JointTrajectoryPoint
 from visualization_msgs.msg import Marker, MarkerArray
 
 import hello_helpers.hello_misc as hm
 import hello_helpers.hello_ros_viz as hr
 
-import copy
-import math
 import os
-import sys
 import threading
 import time
 

--- a/stretch_funmap/stretch_funmap/funmap.py
+++ b/stretch_funmap/stretch_funmap/funmap.py
@@ -1408,7 +1408,6 @@ class FunmapNode(hm.HelloNode):
 
 def main():
     try:
-        rclpy.init()
         node = FunmapNode()
         node.main()
     except KeyboardInterrupt:

--- a/stretch_funmap/stretch_funmap/funmap.py
+++ b/stretch_funmap/stretch_funmap/funmap.py
@@ -193,7 +193,7 @@ class ContactDetector():
                 if position is not None:
                     new_target = self.get_position() + move_increment
                     pose = {joint_name: new_target}
-                    move_to_pose(pose, return_before_done=True)
+                    move_to_pose(pose, blocking=False)
                 time.sleep(0.2)
 
             if self.is_in_contact():
@@ -205,7 +205,7 @@ class ContactDetector():
                 else:
                     new_target = self.get_position() - 0.001  # - 0.002
                 pose = {joint_name: new_target}
-                move_to_pose(pose, return_before_done=False)
+                move_to_pose(pose, blocking=True)
                 self.logger.info(
                     'backing off after contact: moving away from surface to decrease force')
                 success = True
@@ -219,10 +219,10 @@ class ContactDetector():
         return success, message
 
 
-class FunmapNode(Node):
+class FunmapNode(hm.HelloNode):
 
     def __init__(self):
-        super().__init__('stretch_funmap')
+        hm.HelloNode.__init__(self)
 
         self.map_filename = None
         self.debug_directory = None
@@ -243,12 +243,6 @@ class FunmapNode(Node):
         self.wrist_position = None
 
         self.use_hook = False  # True #False
-
-        self.logger = self.get_logger()
-        self.clock = self.get_clock()
-        self.move_to_pose_complete = False
-        self.unsuccessful_status = [-100, 100, FollowJointTrajectory.Result.PATH_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.INVALID_JOINTS, FollowJointTrajectory.Result.INVALID_GOAL, FollowJointTrajectory.Result.GOAL_TOLERANCE_VIOLATED, FollowJointTrajectory.Result.OLD_HEADER_TIMESTAMP]
-        self._get_result_future = None
 
         self.point_cloud_lock = threading.Lock()
         self.map_odom_tf_lock = threading.Lock()
@@ -469,7 +463,7 @@ class FunmapNode(Node):
                     safe_target_m = safe_target_m + 0.03
                 if safe_target_m > self.wrist_position:
                     pose = {'wrist_extension': safe_target_m}
-                    self.move_to_pose(pose, return_before_done=False)
+                    self.move_to_pose(pose, blocking=True)
 
                 # target depth within the surface
                 target_depth_m = 0.08
@@ -1289,100 +1283,6 @@ class FunmapNode(Node):
             self.logger.error(message)
         return result
 
-    def goal_response(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            # self.logger.info("Future goal result is not set")
-            return False
-        goal_handle = future.result()
-        if not goal_handle.accepted:
-            self.move_to_pose_complete = True
-            return
-
-        self._get_result_future = goal_handle.get_result_async()
-
-    def get_result(self, future: rclpy.task.Future):
-        if not future or not future.result():
-            return
-
-        result = future.result().result
-        error_code = result.error_code
-        # self.logger.info('The Action Server has finished, it returned: "%s"' % str(error_code))
-        self.move_to_pose_complete = True
-    
-    def move_to_pose(self, pose, return_before_done=False, custom_contact_thresholds=False):
-        self.move_to_pose_complete = False
-        joint_names = [key for key in pose]
-        point = JointTrajectoryPoint()
-        point.time_from_start = Duration(seconds=0.0).to_msg()
-
-        trajectory_goal = FollowJointTrajectory.Goal()
-        trajectory_goal.goal_time_tolerance = Duration(seconds=1.0).to_msg()
-        trajectory_goal.trajectory.joint_names = joint_names
-        if not custom_contact_thresholds: 
-            joint_positions = [pose[key] for key in joint_names]
-            point.positions = joint_positions
-            trajectory_goal.trajectory.points = [point]
-        else:
-            pose_correct = all([len(pose[key])==2 for key in joint_names])
-            if not pose_correct:
-                self.logger.error("HelloNode.move_to_pose: Not sending trajectory due to improper pose. custom_contact_thresholds requires 2 values (pose_target, contact_threshold_effort) for each joint name, but pose = {0}".format(pose))
-                return
-            joint_positions = [pose[key][0] for key in joint_names]
-            joint_efforts = [pose[key][1] for key in joint_names]
-            point.positions = joint_positions
-            point.effort = joint_efforts
-            trajectory_goal.trajectory.points = [point]
-        trajectory_goal.trajectory.header.stamp = self.get_clock().now().to_msg()
-        self._send_goal_future = self.trajectory_client.send_goal_async(trajectory_goal)
-
-        if not return_before_done:
-            time_start = time.time()
-            self._get_result_future = None
-
-            while not self._get_result_future and (time.time() - time_start) < 10:
-                self.goal_response(self._send_goal_future)
-
-            if not self._get_result_future:
-                return self._send_goal_future
-
-            time_start = time.time()
-            while not self.move_to_pose_complete and (time.time() - time_start) < 10:
-                self.get_result(self._get_result_future)
-        
-        return self._send_goal_future
-
-    def get_robot_floor_pose_xya(self, floor_frame='odom'):
-        # Returns the current estimated x, y position and angle of the
-        # robot on the floor. This is typically called with respect to
-        # the odom frame or the map frame. x and y are in meters and
-        # the angle is in radians.
-        
-        # Navigation planning is performed with respect to a height of
-        # 0.0, so the heights of transformed points are 0.0. The
-        # simple method of handling the heights below assumes that the
-        # frame is aligned such that the z axis is normal to the
-        # floor, so that ignoring the z coordinate is approximately
-        # equivalent to projecting a point onto the floor.
-        
-        # Query TF2 to obtain the current estimated transformation
-        # from the robot's base_link frame to the frame.
-        robot_to_odom_mat, timestamp = hm.get_p1_to_p2_matrix('base_link', floor_frame, self.tf2_buffer)
-        print('robot_to_odom_mat =', robot_to_odom_mat)
-        print('timestamp =', timestamp)
-
-        # Find the robot's current location in the frame.
-        r0 = np.array([0.0, 0.0, 0.0, 1.0])
-        print('r0 =', r0)
-        r0 = np.matmul(robot_to_odom_mat, r0)[:2]
-
-        # Find the current angle of the robot in the frame.
-        r1 = np.array([1.0, 0.0, 0.0, 1.0])
-        r1 = np.matmul(robot_to_odom_mat, r1)[:2]
-        robot_forward = r1 - r0
-        r_ang = np.arctan2(robot_forward[1], robot_forward[0])
-
-        return [r0[0], r0[1], r_ang], timestamp
-
     def publish_map_to_odom_tf(self):
         while rclpy.ok():
             with self.map_odom_tf_lock:
@@ -1391,10 +1291,13 @@ class FunmapNode(Node):
                 time.sleep(0.2)
 
     def main(self):
-        self.declare_parameter('debug_directory', '')
+        hm.HelloNode.main(self, 'funmap', 'funmap')
+        
+        self.logger = self.get_logger()
+        self.clock = self.get_clock()
+        
         self.debug_directory = self.get_parameter('debug_directory').value
 
-        self.declare_parameter('map_yaml', '')
         self.map_filename = self.get_parameter('map_yaml').value
 
         self.merged_map = None
@@ -1485,45 +1388,12 @@ class FunmapNode(Node):
             JointState, '/stretch/joint_states', self.joint_states_callback, 1, callback_group=self.callback_group)
 
         self.move_base = nv.MoveBase(self, self.debug_directory)
-        
-        self.trajectory_client = ActionClient(self, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory')
-        server_reached = self.trajectory_client.wait_for_server(timeout_sec=60.0)
-        if not server_reached:
-            self.logger.error('Unable to connect to arm action server. Timeout exceeded.')
-            sys.exit()
-
-        self.tf2_buffer = tf2_ros.Buffer()
-        self.tf2_listener = tf2_ros.TransformListener(self.tf2_buffer, self)
-
-        self.point_cloud_subscriber = self.create_subscription(PointCloud2, '/camera/depth/color/points', self.point_cloud_callback, 1, callback_group=self.callback_group)
-        # self.point_cloud_pub = self.create_publisher(PointCloud2, '/funmap/point_cloud2', 1)
-
-        self.stop_the_robot_service = self.create_client(Trigger, '/stop_the_robot', callback_group=self.callback_group)
-        while not self.stop_the_robot_service.wait_for_service(timeout_sec=2.0):
-            self.get_logger().info("Waiting on '/stop_the_robot' service...")
-        self.logger.info('Node ' + self.get_name() + ' connected to /stop_the_robot service.')
 
         hz = 5.0
         self.rate = self.create_rate(hz, self.get_clock())
 
-        # Do not start until a point cloud has been received
-        with self.point_cloud_lock:
-            point_cloud_msg = self.point_cloud
-        self.get_logger().info('Node ' + self.get_name() + ' waiting to receive first point cloud.')
-        while point_cloud_msg is None:
-            # self.rate.sleep()
-            time.sleep(0.2)
-            # self.get_logger().info("Spinning...")
-            rclpy.spin_once(self)
-            with self.point_cloud_lock:
-                point_cloud_msg = self.point_cloud
-        self.get_logger().info('Node ' + self.get_name() + ' received first point cloud, so continuing.')
-
         with self.map_odom_tf_lock:
             self.map_to_odom_transform_mat = np.identity(4)
-
-        executor = MultiThreadedExecutor(num_threads=6)
-        executor.add_node(self)
 
         self.map_odom_tf_thread = threading.Thread(target=self.publish_map_to_odom_tf)
         self.map_odom_tf_thread.start()
@@ -1531,7 +1401,7 @@ class FunmapNode(Node):
         self.publish_map_point_cloud_thread = threading.Thread(target=self.publish_map_point_cloud)
         self.publish_map_point_cloud_thread.start()
 
-        executor.spin()
+        self.new_thread.join()
 
         self.map_odom_tf_thread.join()
         self.publish_map_point_cloud_thread.join()

--- a/stretch_funmap/stretch_funmap/manipulation_planning.py
+++ b/stretch_funmap/stretch_funmap/manipulation_planning.py
@@ -8,7 +8,6 @@ from rclpy.time import Time
 import hello_helpers.hello_misc as hm
 import ros2_numpy as rn
 
-import math
 import os
 import time
 
@@ -18,7 +17,6 @@ import scipy.ndimage as nd
 import scipy.signal as si
 import skimage as sk
 
-from . import max_height_image as mh
 from .numba_manipulation_planning import numba_find_base_poses_that_reach_target, numba_check_that_tool_can_deploy
 from .numba_check_line_path import numba_find_contact_along_line_path, numba_find_line_path_on_surface
 from . import ros_max_height_image as rm

--- a/stretch_funmap/stretch_funmap/mapping.py
+++ b/stretch_funmap/stretch_funmap/mapping.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
 
-import rclpy
-from rclpy.clock import Clock
-from rclpy.duration import Duration
-import rclpy.logging
-import rclpy.time
-
 from builtin_interfaces.msg import Time
 import ros2_numpy as rn
 import tf_transformations
@@ -21,9 +15,7 @@ import numpy as np
 import scipy.ndimage as nd
 
 from . import merge_maps as mm
-from . import navigation_planning as na
 from . import ros_max_height_image as rm
-from . import segment_max_height_image as sm
 
 def stow_and_lower_arm(node):
     pose = {'joint_gripper_finger_left': -0.15}

--- a/stretch_funmap/stretch_funmap/max_height_image.py
+++ b/stretch_funmap/stretch_funmap/max_height_image.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 
-from collections import deque
 from copy import deepcopy
 import gzip
-import math
-import struct
-import sys
-import threading
 import yaml
 
 import cv2
 import numpy as np
-from scipy.spatial.transform import Rotation
 
 from . import numba_height_image as nh
-from .numba_create_plane_image import numba_create_plane_image, numba_correct_height_image, transform_original_to_corrected, transform_corrected_to_original
+from .numba_create_plane_image import numba_correct_height_image
 
 class Colormap:
     def __init__(self, colormap=cv2.COLORMAP_HSV):

--- a/stretch_funmap/stretch_funmap/merge_maps.py
+++ b/stretch_funmap/stretch_funmap/merge_maps.py
@@ -2,22 +2,10 @@
 
 import tf_transformations
 
-import hello_helpers.hello_misc as hm
-
-import copy
 import cv2
-import math
-import time
 
 import cma
 import numpy as np
-from scipy.optimize import minimize, minimize_scalar
-import scipy.ndimage as nd
-import scipy.signal as si
-
-from . import mapping as ma
-from . import max_height_image as mh
-from . import navigation_planning as na
 from .numba_compare_images import numba_compare_images_2
 
 def affine_transform_2d_point(affine_matrix, point):

--- a/stretch_funmap/stretch_funmap/navigate.py
+++ b/stretch_funmap/stretch_funmap/navigate.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import rclpy
-from rclpy.duration import Duration
-from rclpy.clock import Clock, ClockType
 import rclpy.logging
 import rclpy.task
 
@@ -12,7 +10,6 @@ from std_srvs.srv import Trigger
 
 import hello_helpers.hello_misc as hm
 
-from functools import partial
 import os
 import time
 

--- a/stretch_funmap/stretch_funmap/navigation_planning.py
+++ b/stretch_funmap/stretch_funmap/navigation_planning.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
 
-import hello_helpers.hello_misc as hm
-
-import copy
-
 import cv2
 import numpy as np
 import scipy.ndimage as nd

--- a/stretch_funmap/stretch_funmap/ros_max_height_image.py
+++ b/stretch_funmap/stretch_funmap/ros_max_height_image.py
@@ -5,22 +5,11 @@ from rclpy.duration import Duration
 import rclpy.logging
 from rclpy.time import Time
 
-from geometry_msgs.msg import Transform, Pose, Vector3, Quaternion, Point
-from nav_msgs.msg import OccupancyGrid, MapMetaData
 import ros2_numpy
 from sensor_msgs.msg import PointCloud2
-from std_msgs.msg import Header
 import tf2_ros
-from visualization_msgs.msg import Marker, MarkerArray
+from visualization_msgs.msg import Marker
 
-from collections import deque
-from copy import deepcopy
-import math
-import struct
-import sys
-import threading
-
-import cv2
 import numpy as np
 from scipy.spatial.transform import Rotation
 

--- a/stretch_funmap/stretch_funmap/segment_max_height_image.py
+++ b/stretch_funmap/stretch_funmap/segment_max_height_image.py
@@ -12,7 +12,6 @@ import scipy.signal as si
 import skimage as sk
 from skimage.morphology import convex_hull_image
 
-from . import max_height_image as mh
 from . import navigation_planning as na
 from .numba_height_image import numba_create_segment_image_uint8
 


### PR DESCRIPTION
This PR makes several changes to the stretch_funmap package:
1. Inherits the class FunmapNode from the HelloNode class instead of the Node class
2. Updates the execution of publish_map_to_odom_tf() and publish_map_point_cloud() methods as timer callbacks instead of defining explicit threads for each
3. Cleans up stray imports in all scripts in stretch_funmap package