### PR TITLE
Update aruco detection API for opencv >= 4.7.0

### DIFF
--- a/stretch_core/stretch_core/detect_aruco_markers.py
+++ b/stretch_core/stretch_core/detect_aruco_markers.py
@@ -187,17 +187,25 @@ class ArucoMarker:
     
     def update(self, corners, timestamp, frame_number, camera_info, depth_image=None):
         self.ready = True
-        self.corners = corners        
+        self.corners = corners
         self.timestamp = timestamp
         self.frame_number = frame_number
         self.camera_info = camera_info
         self.depth_image = depth_image
         self.camera_matrix = np.reshape(self.camera_info.k, (3,3))
         self.distortion_coefficients = np.array(self.camera_info.d)
-        rvecs, tvecs, unknown_variable = aruco.estimatePoseSingleMarkers([self.corners],
-                                                                         self.length_of_marker_mm,
-                                                                         self.camera_matrix,
-                                                                         self.distortion_coefficients)
+        rvecs = np.zeros((len(self.corners), 1, 3), dtype=np.float64)
+        tvecs = np.zeros((len(self.corners), 1, 3), dtype=np.float64)
+        points_3D = np.array([
+            (-self.length_of_marker_mm / 2, self.length_of_marker_mm / 2, 0),
+            (self.length_of_marker_mm / 2, self.length_of_marker_mm / 2, 0),
+            (self.length_of_marker_mm / 2, -self.length_of_marker_mm / 2, 0),
+            (-self.length_of_marker_mm / 2, -self.length_of_marker_mm / 2, 0),
+        ])
+        for marker_num in range(len(self.corners)):
+            unknown_variable, rvecs_ret, tvecs_ret = cv2.solvePnP(objectPoints=points_3D, imagePoints=self.corners[marker_num], cameraMatrix=self.camera_matrix, distCoeffs=self.distortion_coefficients)                                              
+            rvecs[marker_num][:] = np.transpose(rvecs_ret)
+            tvecs[marker_num][:] = np.transpose(tvecs_ret)
         self.aruco_rotation = rvecs[0][0]
         
         # Convert ArUco position estimate to be in meters.
@@ -534,6 +542,7 @@ class ArucoMarkerCollection:
         self.aruco_detection_parameters.cornerRefinementMethod = aruco.CORNER_REFINE_SUBPIX
         self.aruco_detection_parameters.cornerRefinementWinSize = 2
         self.collection = {}
+        self.detector = aruco.ArucoDetector(self.aruco_dict, self.aruco_detection_parameters)
         self.frame_number = 0
 
     def __iter__(self):
@@ -545,7 +554,7 @@ class ArucoMarkerCollection:
                 yield marker
 
     def draw_markers(self, image):
-        return aruco.drawDetectedMarkers(image, self.aruco_corners, self.aruco_ids)
+        return self.detector.drawDetectedMarkers(image, self.aruco_corners, self.aruco_ids)
 
     def broadcast_tf(self, tf_broadcaster):
         # Create TF frames for each of the markers. Only broadcast each
@@ -562,9 +571,7 @@ class ArucoMarkerCollection:
         self.depth_image = depth_image
         self.gray_image = cv2.cvtColor(self.rgb_image, cv2.COLOR_BGR2GRAY)
         image_height, image_width = self.gray_image.shape
-        self.aruco_corners, self.aruco_ids, aruco_rejected_image_points = aruco.detectMarkers(self.gray_image,
-                                                                                              self.aruco_dict,
-                                                                                              parameters = self.aruco_detection_parameters)
+        self.aruco_corners, self.aruco_ids, aruco_rejected_image_points = self.detector.detectMarkers(self.gray_image)
         if self.aruco_ids is None:
             num_detected = 0
         else:


### PR DESCRIPTION
This PR updates the detect_aruco_node to conform with the API changes for the aruco module in opencv versions greater than 4.7.0.

Tested the changes along with opencv-contrib-python version 4.8.0.