### PR TITLE
Fix mismatched IMU mobile base link / topic

### DIFF
--- a/stretch_description/batch/guthrie/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/guthrie/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/hank/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/hank/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/irma/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/irma/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/joplin/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/joplin/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/kendrick/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/kendrick/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/louis/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/louis/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/mitski/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/mitski/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/nina/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/nina/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/otis/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/otis/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/batch/prince/urdf/stretch_base_imu.xacro
+++ b/stretch_description/batch/prince/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_description/urdf/stretch_base_imu.xacro
+++ b/stretch_description/urdf/stretch_base_imu.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_base_imu">
 
 <link
-    name="base_imu">
+    name="imu_mobile_base">
     <inertial>
       <origin
         xyz="0.00300349280517617 0.00149777182047641 -0.00193103885249443"
@@ -50,7 +50,7 @@
     <parent
       link="base_link" />
     <child
-      link="base_imu" />
+      link="imu_mobile_base" />
     <axis
       xyz="0 0 0" />
   </joint>

--- a/stretch_rtabmap/rviz/rtabmap.rviz
+++ b/stretch_rtabmap/rviz/rtabmap.rviz
@@ -65,7 +65,7 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
-        base_imu:
+        imu_mobile_base:
           Alpha: 1
           Show Axes: false
           Show Trail: false


### PR DESCRIPTION
As of PR #95, the Stretch base IMU xacro is included every time a URDF is generated. This includes the URDF link corresponding to the mobile base IMU. This link has been called 'base_imu' in the past, but the topic from the driver refers to a nonexistent link called 'imu_mobile_base'. To fix the mismatch, the xacro's link is renamed from 'base_imu' to 'imu_mobile_base'.