### PR TITLE
Add a timestamp to usb cam images

### DIFF
--- a/stretch_core/stretch_core/usb_cam.py
+++ b/stretch_core/stretch_core/usb_cam.py
@@ -153,6 +153,7 @@ class USBCamNode(Node):
             ret, image_uvc = self.uvc_camera.read()
             # Convert the OpenCV image to a ROS Image message
             self.image_msg = self.cv_bridge.cv2_to_imgmsg(image_uvc, encoding='bgr8')
+            self.image_msg.header.stamp = self.get_clock().now().to_msg()
             self.latency.update()
         except Exception as e:
             print(f"Error UVC Cam: {e}")


### PR DESCRIPTION
# Description

This PR adds a timestamp to messages published by `usb_cam`, which makes it easier to debug latency.

# Testing

- [x] `ros2 launch stretch_core navigation_camera.launch.py`
- [x] `ros2 topic echo /navigation_camera/image_raw | grep sec` Verify it is correct.