### PR TITLE
Support backwards compatibility for lidar baudrate

### DIFF
--- a/stretch_core/launch/rplidar.launch.py
+++ b/stretch_core/launch/rplidar.launch.py
@@ -13,13 +13,14 @@ try:
     default_baudrate = str(lidar_dev.params['baud'])
 except KeyError:
     default_baudrate = '115200'
-configurable_parameters = [{'name': 'serial_port',      'default': str(lidar_dev.params['usb_name']),   'description':"'Specifying usb port to connected lidar'"},
-                           {'name': 'serial_baudrate',  'default': default_baudrate,                    'description':"'Specifying usb port baudrate to connected lidar'"},
-                           {'name': 'frame_id',         'default': 'laser',                             'description':"'Specifying frame_id of lidar'"},
-                           {'name': 'inverted',         'default': 'false',                             'description':"'Specifying whether or not to invert scan data'"},
-                           {'name': 'angle_compensate', 'default': 'true',                              'description':"'Specifying whether or not to enable angle_compensate of scan data'"},
-                           {'name': 'scan_mode',        'default': 'Boost',                             'description':"''"}, # Check if this is supported
-                           ]
+configurable_parameters = [
+    {'name': 'serial_port',      'default': str(lidar_dev.params['usb_name']),   'description':"'Specifying usb port to connected lidar'"},
+    {'name': 'serial_baudrate',  'default': default_baudrate,                    'description':"'Specifying usb port baudrate to connected lidar'"},
+    {'name': 'frame_id',         'default': 'laser',                             'description':"'Specifying frame_id of lidar'"},
+    {'name': 'inverted',         'default': 'false',                             'description':"'Specifying whether or not to invert scan data'"},
+    {'name': 'angle_compensate', 'default': 'true',                              'description':"'Specifying whether or not to enable angle_compensate of scan data'"},
+    {'name': 'scan_mode',        'default': 'Boost',                             'description':"''"}, # Check if this is supported
+]
 
 # lidar supported modes
 # Standard: max_distance: 12.0 m, Point number: 2.0K

--- a/stretch_core/launch/rplidar.launch.py
+++ b/stretch_core/launch/rplidar.launch.py
@@ -9,12 +9,16 @@ from launch.event_handlers import OnShutdown
 from stretch_body.device import Device
 
 lidar_dev = Device('lidar')
+try:
+    default_baudrate = str(lidar_dev.params['baud'])
+except KeyError:
+    default_baudrate = '115200'
 configurable_parameters = [{'name': 'serial_port',      'default': str(lidar_dev.params['usb_name']),   'description':"'Specifying usb port to connected lidar'"},
-                           {'name': 'serial_baudrate',  'default': str(lidar_dev.params['baud']),           'description':"'Specifying usb port baudrate to connected lidar'"},
-                           {'name': 'frame_id',         'default': 'laser',            'description':"'Specifying frame_id of lidar'"},
-                           {'name': 'inverted',         'default': 'false',            'description':"'Specifying whether or not to invert scan data'"},
-                           {'name': 'angle_compensate', 'default': 'true',             'description':"'Specifying whether or not to enable angle_compensate of scan data'"},
-                           {'name': 'scan_mode',        'default': 'Boost',            'description':"''"}, # Check if this is supported
+                           {'name': 'serial_baudrate',  'default': default_baudrate,                    'description':"'Specifying usb port baudrate to connected lidar'"},
+                           {'name': 'frame_id',         'default': 'laser',                             'description':"'Specifying frame_id of lidar'"},
+                           {'name': 'inverted',         'default': 'false',                             'description':"'Specifying whether or not to invert scan data'"},
+                           {'name': 'angle_compensate', 'default': 'true',                              'description':"'Specifying whether or not to enable angle_compensate of scan data'"},
+                           {'name': 'scan_mode',        'default': 'Boost',                             'description':"''"}, # Check if this is supported
                            ]
 
 # lidar supported modes


### PR DESCRIPTION
# Description

Addresses issue #145 and #142 . Essentially, previous versions of `stretch_body` don't have the `baud` parameter in their device. Further, because launchfiles don't do a good job catching/printing errors, the specific exception results in the launchfile silently executing, making it very hard for users to pinpoint the issue. This PR encases that parameter check within a try/except statement.

# Testing

- [x] Downgrade `stretch_body`: `python3 -m pip install hello-robot-stretch-body==0.7.22`
- [x] **Recreate the issue**: pull on `master`, re-build the workspace, and run `ros2 launch stretch_core rplidar.launch.py`. Verify it crashes with on explanation.
- [x] **Verify the fix**: Pull this branch, re-build the workspace, and run `ros2 launch stretch_core rplidar.launch.py`. Verify it succeeds.