### PR TITLE
Fix PID whine noise from wheels during vel control

### DIFF
--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -128,15 +128,16 @@ class StretchDriver(Node):
         else:
             self.gamepad_teleop.update_gamepad_state(self.robot) # Update gamepad input readings within gamepad_teleop instance
         
-        # set new mobile base velocities, if appropriate
-        # check on thread safety for this with callback that sets velocity command values
+        # Set new mobile base velocities
         if self.robot_mode == 'navigation':
             time_since_last_twist = self.get_clock().now() - self.last_twist_time
             if time_since_last_twist < self.timeout:
                 self.robot.base.set_velocity(self.linear_velocity_mps, self.angular_velocity_radps)
                 # self.robot.push_command() #Moved to main
+            elif time_since_last_twist < Duration(seconds=self.timeout_s+1.0):
+                self.robot.base.translate_by(0)
+                # self.robot.push_command() #Moved to main
             else:
-                # Too much information in general, although it could be blocked, since it's just INFO.
                 self.robot.base.set_velocity(0.0, 0.0)
                 # self.robot.push_command() #Moved to main
 


### PR DESCRIPTION
Given a command, the wheels attempt to achieve it using PID controllers in the firmware. Ideally, the controller closes the error between the commanded position and the current one. But actually, this isn't always possible. For example, if the goal requires the robot to be within an obstacle, the controller will push against the obstacle, making no progress, and emitting a whining noise from the wheel motors. Another example, on carpet, the controller will find it difficult to achieve the goal exactly, due to the soft flooring. Unable to close the small error, but trying all the same, the wheel motors emit a noise. Tuning the PID parameters is no good because what works well on carpet will overshoot on hardwood, and vice versa.

In this commit, we relax the controller 0.5 sec after the user stops sending velocity commands, eliminating the wheel noise. Note that this commit only address wheel noise in velocity mode and a future change will be needed to address it in position mode.