### PR TITLE
Address thread starvation bug on joint trajectory server preemption

### DIFF
--- a/stretch_core/stretch_core/joint_trajectory_server.py
+++ b/stretch_core/stretch_core/joint_trajectory_server.py
@@ -96,6 +96,10 @@ class JointTrajectoryAction:
                 # self._goal_handle.abort() \TODO(@hello-atharva): This is causing state transition issues.
             self._goal_handle = goal_handle
 
+        # Increment goal ID
+        self.latest_goal_id += 1
+
+        # Launch an asynch coroutine to execute the goal
         goal_handle.execute()
     
     def execute_cb(self, goal_handle):
@@ -106,8 +110,7 @@ class JointTrajectoryAction:
             pickle.dump(goal, s)
 
         # Register this goal's ID
-        goal_id = self.latest_goal_id + 1
-        self.latest_goal_id += 1
+        goal_id = self.latest_goal_id
         
         with self.node.robot_stop_lock:
             # Escape stopped mode to execute trajectory

--- a/stretch_core/stretch_core/joint_trajectory_server.py
+++ b/stretch_core/stretch_core/joint_trajectory_server.py
@@ -34,7 +34,6 @@ class JointTrajectoryAction:
         self.node = node
         self._goal_handle = None
         self._goal_lock = threading.Lock()
-        self.action_server_rate = self.node.create_rate(action_server_rate_hz)
         self.server = ActionServer(self.node, FollowJointTrajectory, '/stretch_controller/follow_joint_trajectory',
                                    execute_callback=self.execute_cb,
                                    cancel_callback=self.cancel_cb,
@@ -309,9 +308,9 @@ class JointTrajectoryAction:
                 self.feedback_callback(goal_handle, start_time=ts)
                 # self.action_server_rate.sleep()
 
-            # TODO: We should change time.sleep to self.action_server_rate.sleep(),
-            # so control is handed back to the executor to handle other callbacks
-            # while sleeping. This requires enough threads in the executor to process
+            # TODO: We should change time.sleep to a rate.sleep(), so control
+            # is handed back to the executor to handle other callbacks while
+            # sleeping. This requires enough threads in the executor to process
             # all callbacks we expect to fire in parallel.
             time.sleep(0.1)
             self.node.robot_mode_rwlock.release_read()

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -991,7 +991,7 @@ class StretchDriver(Node):
 def main():
     try:
         rclpy.init()
-        executor = MultiThreadedExecutor(num_threads=2)
+        executor = MultiThreadedExecutor(num_threads=5)
         node = StretchDriver()
         node.joint_trajectory_action = JointTrajectoryAction(node, node.action_server_rate)
         executor.add_node(node)

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -5,6 +5,7 @@ import yaml
 import numpy as np
 import threading
 from .rwlock import RWLock
+from typing import List
 import stretch_body.robot as rb
 from stretch_body import gamepad_teleop
 import stretch_body
@@ -18,6 +19,7 @@ from rclpy.duration import Duration
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 
 from geometry_msgs.msg import Twist
 from geometry_msgs.msg import TransformStamped
@@ -26,6 +28,7 @@ from std_srvs.srv import Trigger
 from std_srvs.srv import SetBool
 
 from nav_msgs.msg import Odometry
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType, SetParametersResult
 from sensor_msgs.msg import BatteryState, JointState, Imu, MagneticField, Joy
 from std_msgs.msg import Bool, String
 
@@ -44,9 +47,6 @@ class StretchDriver(Node):
         super().__init__('stretch_driver')
         self.use_robotis_head = True
         self.use_robotis_end_of_arm = True
-
-        self.default_goal_timeout_s = 10.0
-        self.default_goal_timeout_duration = Duration(seconds=self.default_goal_timeout_s)
 
         # Initialize calibration offsets
         self.head_tilt_calibrated_offset_rad = 0.0
@@ -702,6 +702,17 @@ class StretchDriver(Node):
         response.message = f'is self collision avoidance enabled: {enable_self_collision_avoidance}'
         return response
 
+    def parameter_callback(self, parameters: List[Parameter]) -> SetParametersResult:
+        """
+        Update the parameters that allow for dynamic updates.
+        """
+        for parameter in parameters:
+            if parameter.name == "default_goal_timeout_s":
+                self.default_goal_timeout_s = parameter.value
+                self.default_goal_timeout_duration = Duration(seconds=self.default_goal_timeout_s)
+                self.get_logger().info(f"Set default_goal_timeout_s to {self.default_goal_timeout_s}")
+        return SetParametersResult(successful=True)
+
     def home_the_robot(self):
         self.robot_mode_rwlock.acquire_read()
         can_home = self.robot_mode in self.control_modes
@@ -893,9 +904,18 @@ class StretchDriver(Node):
 
         self.declare_parameter('rate', 30.0)
         self.joint_state_rate = self.get_parameter('rate').value
-        self.declare_parameter('timeout', 0.5)
+        self.declare_parameter('timeout', 0.5, ParameterDescriptor(
+            type=ParameterType.PARAMETER_DOUBLE,
+            description='Timeout (sec) after which Twist/Joy commands are considered stale',
+        ))
         self.timeout_s = self.get_parameter('timeout').value
         self.timeout = Duration(seconds=self.timeout_s)
+        self.declare_parameter('default_goal_timeout_s', 10.0, ParameterDescriptor(
+            type=ParameterType.PARAMETER_DOUBLE,
+            description='Default timeout (sec) for goal execution',
+        ))
+        self.default_goal_timeout_s = self.get_parameter('default_goal_timeout_s').value
+        self.default_goal_timeout_duration = Duration(seconds=self.default_goal_timeout_s)
         self.get_logger().info(f"rate = {self.joint_state_rate} Hz")
         self.get_logger().info(f"twist timeout = {self.timeout_s} s")
 
@@ -916,6 +936,9 @@ class StretchDriver(Node):
         
         self.declare_parameter('action_server_rate', 30.0)
         self.action_server_rate = self.get_parameter('action_server_rate').value
+
+        # Add a callback for updating parameters
+        self.add_on_set_parameters_callback(self.parameter_callback)
 
         self.diagnostics = StretchDiagnostics(self, self.robot)
 

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -995,7 +995,6 @@ def main():
         node = StretchDriver()
         node.joint_trajectory_action = JointTrajectoryAction(node, node.action_server_rate)
         executor.add_node(node)
-        executor.add_node(node.joint_trajectory_action)
         try:
             executor.spin()
         finally:

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -5,7 +5,6 @@ import yaml
 import numpy as np
 import threading
 from .rwlock import RWLock
-from typing import List
 import stretch_body.robot as rb
 from stretch_body import gamepad_teleop
 import stretch_body
@@ -702,7 +701,7 @@ class StretchDriver(Node):
         response.message = f'is self collision avoidance enabled: {enable_self_collision_avoidance}'
         return response
 
-    def parameter_callback(self, parameters: List[Parameter]) -> SetParametersResult:
+    def parameter_callback(self, parameters: list[Parameter]) -> SetParametersResult:
         """
         Update the parameters that allow for dynamic updates.
         """


### PR DESCRIPTION
# Description

There is a thread starvation race condition in `stretch_driver` / `joint_trajectory_server`. Consider the following scenario, where steps 2 and 3 happen in quick succession:
1. `stretch_driver` receives a joint trajectory server goal.
2. `stretch_driver` receives another joint trajectory server goal.
3. `stretch_driver` receives a change mode request.

The expected behavior here is that the second goal will preempt the first, then the second goal will execute, and then the change mode request will be processed. 

In actuality, the following can happen. Note that [the executor is only allocated two threads](https://github.com/hello-robot/stretch_ros2/blob/d8ce9660e3d922cbdfc6d18f3cb887ba2b38e2b2/stretch_core/stretch_core/stretch_driver.py#L971) to process all callbacks.
1. The first goal's execution callback [locks `robot_mode_rwlock`](https://github.com/hello-robot/stretch_ros2/blob/d8ce9660e3d922cbdfc6d18f3cb887ba2b38e2b2/stretch_core/stretch_core/joint_trajectory_server.py#L117), and occupies all the resources of one thread (it never handles control back to the executor, [because it uses `time.sleep()`](https://github.com/hello-robot/stretch_ros2/blob/d8ce9660e3d922cbdfc6d18f3cb887ba2b38e2b2/stretch_core/stretch_core/joint_trajectory_server.py#L232) instead of `rate.sleep()`). Thus, _the executor is only left with one thread_ until the first goal's execution completes.
2. The executor receives and accepts the second goal, and [invokes an asynchronous coroutine to execute it](https://github.com/hello-robot/stretch_ros2/blob/d8ce9660e3d922cbdfc6d18f3cb887ba2b38e2b2/stretch_core/stretch_core/joint_trajectory_server.py#L101). Thus, control of that thread is handed back to the executor, with two items of work on its wait set: the change mode service callback, and the action execution coroutine.
3. Sometimes, the switch mode service's callback gets invoked first. This [waits for the `robot_mode_rwlock` to be released](https://github.com/hello-robot/stretch_ros2/blob/d8ce9660e3d922cbdfc6d18f3cb887ba2b38e2b2/stretch_core/stretch_core/stretch_driver.py#L523), which only happens after execution of the first goal finishes. This uses all the resources of the second thread. **_Thus, there are no threads left to process the new goal_**.
4. Because the [`latest_goal_id` is only incremented after the goal starts exeucting](https://github.com/hello-robot/stretch_ros2/blob/d8ce9660e3d922cbdfc6d18f3cb887ba2b38e2b2/stretch_core/stretch_core/joint_trajectory_server.py#L112), and [goal execution uses the `latest_goal_id` to determine whether to preempt](https://github.com/hello-robot/stretch_ros2/blob/d8ce9660e3d922cbdfc6d18f3cb887ba2b38e2b2/stretch_core/stretch_core/joint_trajectory_server.py#L212), the first goal never knows whether to preempt.
5. As a result of this, both threads are occupied until the first goal finishes executing, which could take up to [10s due to hardcoded timeout](https://github.com/hello-robot/stretch_ros2/blob/d8ce9660e3d922cbdfc6d18f3cb887ba2b38e2b2/stretch_core/stretch_core/stretch_driver.py#L48).

This PR implements multiple fixes to address the above bug and cleanup the joint trajectory server. Each fix directly corresponds to one of the commits. 
1. Makes the default goal callback a parameter, which defaults to 10 and can be dynamically changed by the user over the runtime of `stretch_driver`. That way, if their application commands short trajectories, they can reduce the timeout.
2. Remove the unnecessary addition of the joint trajectory server as a Node. It registers all its callbacks under the `stretch_driver` node, so it doesn't need to be a node. This may reduce unnecessary executor computation.
3. Remove the unused `server.action_server_rate`, which invokes callbacks at a rate of 10 Hz and unnecessarily takes up executor compute.
4. Adds a missing release of the read-write lock, which could block execution.
5. Increment the `latest_goal_id` when the goal is accepted, as opposed to when the goal starts executing, so that previous goals know to cancel as soon as a next goal is accepted.
6. For good measure, this PR also increases the number of executor threads to 5. 2 is far too few for the callbacks in the executor.
    1. The node's default `MutuallyExclusiveCallbackGroup` has all services. That needs 1 thread.
    2. The two subscriptions, `cmd_vel` and `gamepad_joy`, have a dedicated `MutuallyExclusiveCallbackGroup`. That needs 1 thread.
    3. There is a timer that calls `command_mobile_base_velocity_and_publish_state` at a rate of 30 Hz, which is what moves the base (and stops it if the motion command is stale). So that timer should have 1 thread available to handle its callbacks.
    4. The action server has a `ReentrantCallbackGroup` for all its callbacks (goal request, cancellation request, execution). We should account for at least 2 actions being executed in parallel (e.g., one action starts executing while the next one is wrapping up and preempting -- this happens quite often). Thus, we should have 2 threads for this.

# Testing

The below script is a minimal example of the problem. Testing was done as detailed below. I did the testing with the tablet on the end-effector, which is helpful because of #141 (where trajectories go till timeout when the wrist has additional force on it).
- [x] **Recreate the issue**:
    - [x] Pull on `humble`, copy the below script into a ROS package and add it to the `CMakeLists.txt` / `setup.py` file.
    - [x] Re-build your workspace.
    - [x] `ros2 launch stretch_core stretch_driver.launch.py`
    - [x] `ros2 run <package_with_the_text_script> stretch_driver_thread_starvation_test.py`
    - [x] Verify that Goal 1 runs to termination before Goal 2 is processed.
- [x] **Verify the fix**:
    - [x] Pull on this branch.
    - [x] Re-build your workspace.
    - [x] `ros2 launch stretch_core stretch_driver.launch.py`
    - [x] `ros2 run <package_with_the_text_script> stretch_driver_thread_starvation_test.py`
    - [x] Verify that Goal 1 gets pre-empted and Goal 2 executes.

## `stretch_driver_thread_starvation_test.py`

(To more reliably re-create the actual race condition, I swap the nav mode callback with the second goal callback, compared with what I wrote above. However, the reality is that even if we follow the steps I wrote above from the web app, it is possible for the requests to get swapped over roslibjs and/or rosbridge.)

```
#! /usr/bin/env python3
import time
import threading
from typing import Dict, Optional

import rclpy
from action_msgs.msg import GoalStatus
from control_msgs.action import FollowJointTrajectory
from rclpy.action import ActionClient
from rclpy.duration import Duration
from rclpy.executors import SingleThreadedExecutor
from rclpy.node import Node
from rclpy.task import Future
from std_srvs.srv import Trigger
from trajectory_msgs.msg import JointTrajectoryPoint

# Declare the global variables
node: Optional[Node] = None
trajectory_client: Optional[ActionClient] = None


def move_to(joint_positions: Dict[str, float]) -> Future:
    """
    Move the arm to the given joint positions.

    Parameters
    ----------
    joint_positions : Dict[str, float]
        A dictionary of joint names and their corresponding positions.

    Returns
    -------
    Future
        A future object representing the result of the action.
    """
    global node, trajectory_client
    joint_names = list(joint_positions.keys())

    point1 = JointTrajectoryPoint()
    trajectory_goal = FollowJointTrajectory.Goal()
    trajectory_goal.goal_time_tolerance = Duration(seconds=1.0).to_msg()
    trajectory_goal.trajectory.joint_names = joint_names

    point1.time_from_start = Duration(seconds=10).to_msg()
    point1.positions = [joint_positions[joint_name] for joint_name in joint_names]
    trajectory_goal.trajectory.points = [point1]
    return trajectory_client.send_goal_async(trajectory_goal)


def wait_until_future_finished(future: Future, rate_hz: float = 5.0) -> None:
    """
    Wait until the future is finished.

    Parameters
    ----------
    future : Future
        The future object to wait for.
    rate_hz : float, optional
        The rate at which to check the future, by default 5.0
    """
    global node
    rate = node.create_rate(rate_hz)
    while not future.done():
        rate.sleep()


def get_action_result(
    send_goal_future: Future,
) -> Optional[FollowJointTrajectory.Result]:
    """
    Get the result of the action.

    Parameters
    ----------
    send_goal_future : Future
        The future object representing the result of the action.

    Returns
    -------
    Optional[FollowJointTrajectory.Result]
        The result of the action, if available.
    """
    global node
    # First, wait until the goal is accepted or rejected
    wait_until_future_finished(send_goal_future)

    # Check if the goal was accepted
    goal_handle = send_goal_future.result()
    if not goal_handle.accepted:
        node.get_logger().error("Goal rejected")
        return None

    # Wait until the goal is completed
    get_result_future = goal_handle.get_result_async()
    wait_until_future_finished(get_result_future)

    # Return the result
    goal_status = get_result_future.result()
    if goal_status.status != GoalStatus.STATUS_SUCCEEDED:
        node.get_logger().error("Goal failed")
        return None
    return goal_status.result


def main():
    global node, trajectory_client
    rclpy.init()
    node = rclpy.create_node("move_to_same_pose")
    trajectory_client = ActionClient(
        node, FollowJointTrajectory, "/stretch_controller/follow_joint_trajectory"
    )
    node.get_logger().info("Waiting for the follow joint trajectory controller...")
    _ = trajectory_client.wait_for_server(timeout_sec=60.0)
    switch_to_nav_mode_srv = node.create_client(
        Trigger, '/switch_to_navigation_mode'
    )
    node.get_logger().info("Waiting for the switch to navigation mode service...")
    switch_to_nav_mode_srv.wait_for_service(timeout_sec=60.0)
    switch_to_pos_mode = node.create_client(
        Trigger, '/switch_to_position_mode'
    )
    node.get_logger().info("Waiting for the switch to position mode service...")
    switch_to_pos_mode.wait_for_service(timeout_sec=60.0)


    # Spin the node in the background
    executor = SingleThreadedExecutor()
    spin_thread = threading.Thread(
        target=rclpy.spin,
        args=(node,),
        kwargs={"executor": executor},
        daemon=True,
    )
    spin_thread.start()

    # Create the goal
    goal_0 = {
        "joint_head_tilt": 0.0,
        "joint_head_pan": 0.0,
        "joint_wrist_roll": 0.0,
        "joint_wrist_pitch": 0.0,
        "joint_wrist_yaw": 0.0,
        "joint_lift": 1.1,
        "wrist_extension": 0.0,
    }
    goal_1 = {
        "joint_head_tilt": -0.02766916597432903,
        "joint_head_pan": 0.050683455439404626,
        "joint_wrist_roll": -0.006135923151542565,
        "joint_wrist_pitch": -0.15339807878856412,
        "joint_wrist_yaw": 0.0012783173232380344,
        "joint_lift": 0.5305833379477396,
        "wrist_extension": 0.45,
    }
    goal_2 = {
        "joint_head_tilt": -0.03766916597432903,
        "joint_head_pan": 0.060683455439404626,
        "joint_wrist_roll": -0.016135923151542565,
        "joint_wrist_pitch": -0.16339807878856412,
        "joint_wrist_yaw": 0.0112783173232380344,
        "joint_lift": 0.6305833379477396,
        "wrist_extension": 0.5145,
    }

    # Switch to position mode
    node.get_logger().info("Switching to position mode...")
    switch_to_pos_mode_future = switch_to_pos_mode.call_async(Trigger.Request())
    wait_until_future_finished(switch_to_pos_mode_future)

    # Move to Goal 0
    node.get_logger().info("Moving to goal 0...")
    send_goal_future_0 = move_to(goal_0)
    get_action_result(send_goal_future_0)

    # Move to Goal 1
    node.get_logger().info("Moving to goal 1...")
    send_goal_future_1 = move_to(goal_1)

    # Switch to navigation mode
    node.get_logger().info("Switching to navigation mode...")
    switch_to_nav_mode_future = switch_to_nav_mode_srv.call_async(Trigger.Request())

    # Move to Goal 2
    time.sleep(0.25)
    node.get_logger().info("Moving to goal 2...")
    send_goal_future_2 = move_to(goal_2)

    # Wait for all remaining futures
    node.get_logger().info("Waiting for Goal 1 to finish...")
    get_action_result(send_goal_future_1)
    node.get_logger().info("Waiting for the switch to navigation mode service...")
    wait_until_future_finished(switch_to_nav_mode_future)
    node.get_logger().info("Waiting for Goal 2 to finish...")
    get_action_result(send_goal_future_2)
    node.get_logger().info("Done!")

    # Spin in the foreground
    spin_thread.join()

    # Clean up
    node.destroy_node()
    rclpy.shutdown()


if __name__ == "__main__":
    main()
```