### PR TITLE
Cannot destroy object that is not a node

### DIFF
--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -1096,7 +1096,6 @@ def main():
             executor.spin()
         finally:
             executor.shutdown()
-            node.joint_trajectory_action.destroy_node()
             node.destroy_node()
     except (KeyboardInterrupt, ThreadServiceExit):
         node.gamepad_teleop.stop()


### PR DESCRIPTION
With #150, `JointTrajectoryAction` in Stretch Core is no longer a node. If you `ros2 launch stretch_core stretch_driver.launch.py`, and Ctrl-C out, you'll see the following error:

```
[stretch_driver-3] During handling of the above exception, another exception occurred:
[stretch_driver-3] 
[stretch_driver-3] Traceback (most recent call last):
[stretch_driver-3]   File "/home/hello-robot/ament_ws/install/stretch_core/lib/stretch_core/stretch_driver", line 33, in <module>
[stretch_driver-3]     sys.exit(load_entry_point('stretch-core', 'console_scripts', 'stretch_driver')())
[stretch_driver-3]   File "/home/hello-robot/ament_ws/build/stretch_core/stretch_core/stretch_driver.py", line 1099, in main
[stretch_driver-3]     node.joint_trajectory_action.destroy_node()
[stretch_driver-3] AttributeError: 'JointTrajectoryAction' object has no attribute 'destroy_node'
```

This PR fixes #157 