### PR TITLE
Fix priority modes stalling main loop execution

### DIFF
--- a/stretch_core/stretch_core/joint_trajectory_server.py
+++ b/stretch_core/stretch_core/joint_trajectory_server.py
@@ -15,7 +15,6 @@ import threading
 
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
-from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.duration import Duration
 
 from control_msgs.action import FollowJointTrajectory
@@ -39,7 +38,7 @@ class JointTrajectoryAction:
                                    cancel_callback=self.cancel_cb,
                                    goal_callback=self.goal_cb,
                                    handle_accepted_callback=self.handle_accepted_cb,
-                                   callback_group=ReentrantCallbackGroup())
+                                   callback_group=node.main_group)
         
         self.debug_dir = Path(hu.get_stretch_directory('goals'))
         if not self.debug_dir.exists():


### PR DESCRIPTION
This PR addresses https://github.com/hello-robot/stretch_ros2/issues/156, where topics in the main loop would stall publishing when the driver was performing thread-blocking actions (e.g. homing sequence) because of an incorrectly configured callback groups set-up. Now, all main functionality share an ReentrantCallbackGroup called `main_group`, and the `/cmd_vel` topic's callback gets an MutuallyExclusiveCallbackGroup called `mutex_group` (ensuring two threads don't write to Stretch Body simultaneously; see [thread-safety docs](https://docs.hello-robot.com/0.3/stretch-body/docs/is_thread_safe/)).

This PR also addresses part of #161, namely "Review the state of Stretch Driver's callback groups, ensuring the callbacks are running in the most efficient way possible, and that no deadlocks are possible.", and "Confirm whether all of the callbacks are matched to a single group, or if there is a hidden group." (they previously were, now no longer; Rclpy nodes use a hidden MutuallyExclusiveCallbackGroup for all callbacks when a callback group isn't specified).