### PR TITLE
Exit nav2 launch on map not found error

### DIFF
--- a/stretch_nav2/launch/navigation.launch.py
+++ b/stretch_nav2/launch/navigation.launch.py
@@ -1,7 +1,7 @@
 import os
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, LogInfo
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 from launch.launch_context import LaunchContext


### PR DESCRIPTION
This PR makes the Navigation Launch exit immediately with an error printout if the map file path provided is found to be invalid.
- Raising any Exception within the `generate_launch_description` seems to successfully exit out the launch process immediately and cleanly
- This is accomplished by defining a ros2 launch Action [Opaque function](https://github.com/hello-robot/stretch_ros2/blob/3358af019e5cb217261f26298d1660cd17c77dfd/stretch_nav2/launch/navigation.launch.py#L51) that checks for the `map` argument from the runtime context and raises an `FileNotFoundError` with an error message logged. 

To test run the launch with invalid map path and the output should like the following.
```
ros2 launch stretch_nav2 navigation.launch.py use_rviz:=false map:=~/path/to/map
```
```
[INFO] [launch]: All log files can be found below /home/hello-robot/.ros/log/2024-08-28-16-22-14-936485-stretch-se3-3002-263141
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [1724887336.358491303] [navigation_launch]: Map file not found in given path: ~/path/to/map

```