### PR TITLE
Remove Teleop Twist Joystick in Mapping Launches

### DIFF
--- a/stretch_nav2/launch/offline_mapping.launch.py
+++ b/stretch_nav2/launch/offline_mapping.launch.py
@@ -25,14 +25,13 @@ def generate_launch_description():
 
     stretch_driver_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, '/launch/stretch_driver.launch.py']),
-        launch_arguments={'mode': 'navigation', 'broadcast_odom_tf': 'True'}.items())
+        launch_arguments={'mode': 'gamepad', 'broadcast_odom_tf': 'True'}.items())
 
     rplidar_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, '/launch/rplidar.launch.py']))
 
-    base_teleop_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([stretch_navigation_path, '/launch/teleop_twist.launch.py']),
-        launch_arguments={'teleop_type': LaunchConfiguration('teleop_type')}.items())
+    offline_mapping_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([get_package_share_directory('slam_toolbox'), '/launch/offline_launch.py']))
 
     rviz_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([get_package_share_directory('nav2_bringup'), '/launch/rviz_launch.py']),
@@ -44,7 +43,7 @@ def generate_launch_description():
         declare_use_sim_time_argument,
         stretch_driver_launch,
         rplidar_launch,
-        base_teleop_launch,
+        offline_mapping_launch,
         rviz_launch,
     ])
 

--- a/stretch_nav2/launch/offline_mapping.launch.py
+++ b/stretch_nav2/launch/offline_mapping.launch.py
@@ -30,9 +30,6 @@ def generate_launch_description():
     rplidar_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, '/launch/rplidar.launch.py']))
 
-    offline_mapping_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([get_package_share_directory('slam_toolbox'), '/launch/offline_launch.py']))
-
     rviz_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([get_package_share_directory('nav2_bringup'), '/launch/rviz_launch.py']),
         condition=IfCondition(LaunchConfiguration('use_rviz')))    
@@ -43,7 +40,6 @@ def generate_launch_description():
         declare_use_sim_time_argument,
         stretch_driver_launch,
         rplidar_launch,
-        offline_mapping_launch,
         rviz_launch,
     ])
 

--- a/stretch_rtabmap/launch/visual_mapping.launch.py
+++ b/stretch_rtabmap/launch/visual_mapping.launch.py
@@ -15,8 +15,6 @@ def generate_launch_description():
     rviz_param = DeclareLaunchArgument('use_rviz', default_value='true', choices=['true', 'false'])
     rviz_config = DeclareLaunchArgument('rviz_config',
                                         default_value=stretch_rtabmap_path + '/' + 'rviz/rtabmap.rviz')
-    teleop_type_param = DeclareLaunchArgument(
-        'teleop_type', default_value="joystick", description="how to teleop ('keyboard', 'joystick' or 'none')")
 
     stretch_driver_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, '/launch/stretch_driver.launch.py']),
@@ -38,10 +36,6 @@ def generate_launch_description():
         output='screen',
         )
     
-    base_teleop_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([stretch_navigation_path, '/launch/teleop_twist.launch.py']),
-        launch_arguments={'teleop_type': LaunchConfiguration('teleop_type')}.items())
-    
     rviz_launch = Node(package='rviz2', executable='rviz2',
         output='log',
         condition=IfCondition(LaunchConfiguration('use_rviz')),
@@ -56,6 +50,5 @@ def generate_launch_description():
         stretch_driver_launch,
         d435i_launch,
         rtabmap_mapping_node,
-        base_teleop_launch,
         rviz_launch,
     ])

--- a/stretch_rtabmap/launch/visual_mapping.launch.py
+++ b/stretch_rtabmap/launch/visual_mapping.launch.py
@@ -18,7 +18,7 @@ def generate_launch_description():
 
     stretch_driver_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, '/launch/stretch_driver.launch.py']),
-        launch_arguments={'mode': 'navigation', 'broadcast_odom_tf': 'True'}.items())
+        launch_arguments={'mode': 'gamepad', 'broadcast_odom_tf': 'True'}.items())
 
     d435i_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, '/launch/d435i_high_resolution.launch.py']))


### PR DESCRIPTION
This PR removes the Teleop twist launch in joystick mode which causes USB resource priority issue with the Gamepad controller running in the Stretch Driver process.