### PR TITLE
Use "likelihood_field_prob" `laser_mode_type`

### DIFF
--- a/stretch_nav2/config/nav2_params.yaml
+++ b/stretch_nav2/config/nav2_params.yaml
@@ -16,7 +16,7 @@ amcl:
     laser_likelihood_max_dist: 2.0
     laser_max_range: 100.0
     laser_min_range: -1.0
-    laser_model_type: "likelihood_field"
+    laser_model_type: "likelihood_field_prob"
     max_beams: 60
     max_particles: 2000
     min_particles: 500


### PR DESCRIPTION
Discovered by @hello-vinitha, this change uses the "likelihood_field_prob" for the `laser_mode_type` AMCL parameter. She says:

 > The likelihood_field_prob model doesn't use the ad-hoc weighting scheme for combining beam probs that the likelihood_field model does (taking probabilities to the third power, which seems rather arbitrary, but serves to keep around less-likely hypotheses for much longer). This mode converges much faster and generates more accurate pose estimates when the world matches the map well, since it makes full use of all laser readings to squash non-matching particles. However, it is really only useful when you have a nice laser that generates a wide field-of-view (like Stretch does) with quite accurate measurements. This mode also needs beam-skipping to avoid killing off correct particles due to dynamic obstacles.

TODO

- [ ] Test this change with dynamic obstacles