### PR TITLE
Use /scan_filtered topic when building map

### DIFF
--- a/stretch_nav2/config/mapper_params_online_async.yaml
+++ b/stretch_nav2/config/mapper_params_online_async.yaml
@@ -13,7 +13,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_footprint
-    scan_topic: /scan
+    scan_topic: /scan_filtered
     mode: mapping #localization
 
     # if you'd like to immediately start continuing a map at a given pose

--- a/stretch_nav2/launch/offline_mapping.launch.py
+++ b/stretch_nav2/launch/offline_mapping.launch.py
@@ -3,16 +3,16 @@ import os
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
-
+from ament_index_python.packages import get_package_share_directory, get_package_share_path
 
 def generate_launch_description():
     stretch_core_path = get_package_share_directory('stretch_core')
     stretch_navigation_path = get_package_share_directory('stretch_nav2')
-    
+    navigation_package = str(get_package_share_path("stretch_nav2"))
+
     rviz_param = DeclareLaunchArgument('use_rviz', default_value='true', choices=['true', 'false'])
     
     teleop_type = DeclareLaunchArgument(
@@ -22,12 +22,6 @@ def generate_launch_description():
         'use_sim_time',
         default_value='false',
         description='Use simulation/Gazebo clock')
-
-    declare_slam_params_file_cmd = DeclareLaunchArgument(
-        'slam_params_file',
-        default_value=os.path.join(stretch_navigation_path,
-                                   'config', 'mapper_params_online_async.yaml'),
-        description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
 
     stretch_driver_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, '/launch/stretch_driver.launch.py']),
@@ -40,21 +34,30 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([stretch_navigation_path, '/launch/teleop_twist.launch.py']),
         launch_arguments={'teleop_type': LaunchConfiguration('teleop_type')}.items())
 
-    offline_mapping_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([get_package_share_directory('slam_toolbox'), '/launch/offline_launch.py']))
-
     rviz_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([get_package_share_directory('nav2_bringup'), '/launch/rviz_launch.py']),
         condition=IfCondition(LaunchConfiguration('use_rviz')))    
 
-    return LaunchDescription([
+    ld = LaunchDescription([
         rviz_param,
         teleop_type,
         declare_use_sim_time_argument,
-        declare_slam_params_file_cmd,
         stretch_driver_launch,
         rplidar_launch,
         base_teleop_launch,
-        offline_mapping_launch,
         rviz_launch,
     ])
+
+    ld.add_action(
+        Node(
+            package='slam_toolbox',
+            executable='sync_slam_toolbox_node',
+            name='slam_toolbox',
+            output='screen',
+            parameters=[
+                PathJoinSubstitution([navigation_package, 'config', 'mapper_params_online_async.yaml']),
+            ]
+        )
+    )
+
+    return ld


### PR DESCRIPTION
This PR fixes a bug where ghost objects would appear when generating a map. due to the scan topic (`/scan`) being used by the `sync_slam_toolbox_node` which included the mast. This PR updates the scan topic in the config file to the one where the mast is filtered out (`/scan_filtered`). 
