### PR TITLE
Resolved stretch_funmap/cython_min_cost_path.c compilation error

### DIFF
--- a/stretch_description/README.md
+++ b/stretch_description/README.md
@@ -58,7 +58,7 @@ Sometimes a URDF is useful outside of ROS, such as for simulations and analysis.
 
 ```
 cd ~/ament_ws/src/stretch_ros2/stretch_description/urdf
-./export_urdf.py
+./export_urdf.sh
 ```
 
 Normal output will look like:

--- a/stretch_funmap/setup.py
+++ b/stretch_funmap/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 from Cython.Build import cythonize
 from glob import glob
+import numpy
 
 package_name = 'stretch_funmap'
 cython_files = [package_name+"/cython_min_cost_path.pyx",]
@@ -11,6 +12,7 @@ setup(
     packages=find_packages(),
     # package_data={'stretch_demos': ['*.pyx']},
     ext_modules = cythonize(cython_files, compiler_directives={'language_level': "3"}, force=True, quiet=True),
+    include_dirs = [numpy.get_include()],
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),


### PR DESCRIPTION
Error that has been resolved using this commit:

```
--- stderr: stretch_funmap                                                                                                                                                                              
/usr/lib/python3/dist-packages/pythran/tables.py:4553: FutureWarning: In the future `np.bytes` will be defined as the corresponding NumPy scalar.
  obj = getattr(themodule, elem)
stretch_funmap/cython_min_cost_path.c:1257:10: fatal error: numpy/arrayobject.h: No such file or directory
 1257 | #include "numpy/arrayobject.h"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
error: Command "x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/home/keivalya/ament_ws/install/stretch_funmap/include -I/usr/include/python3.10 -c stretch_funmap/cython_min_cost_path.c -o /home/keivalya/ament_ws/build/stretch_funmap/build/temp.linux-x86_64-3.10/stretch_funmap/cython_min_cost_path.o" failed with exit status 1
---
```

While working with Stretch3, I came across this error which was due to `numpy` dependency not mentioned in `setup.py` of `stretch_funmap` package.