### PR TITLE
Make it easy to run stretch_driver separately

### DIFF
--- a/stretch_core/launch/stretch_driver.launch.py
+++ b/stretch_core/launch/stretch_driver.launch.py
@@ -74,4 +74,5 @@ def generate_launch_description():
                               declare_controller_arg,
                               joint_state_publisher,
                               robot_state_publisher,
-                              stretch_driver])
+                              stretch_driver,
+                              ])

--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -38,6 +38,8 @@ from hello_helpers.gamepad_conversion import unpack_joy_to_gamepad_state, unpack
 from .joint_trajectory_server import JointTrajectoryAction
 from .stretch_diagnostics import StretchDiagnostics
 
+from ament_index_python.packages import get_package_share_path
+
 GRIPPER_DEBUG = False
 BACKLASH_DEBUG = False
 STREAMING_POSITION_DEBUG = False
@@ -899,7 +901,8 @@ class StretchDriver(Node):
 
         large_ang = np.radians(45.0)
 
-        self.declare_parameter('controller_calibration_file', 'NOT SET')
+        stretch_core_path = get_package_share_path('stretch_core')
+        self.declare_parameter('controller_calibration_file', str(stretch_core_path / 'config' / 'controller_calibration_head.yaml'))
         filename = self.get_parameter('controller_calibration_file').value
         self.get_logger().debug('Loading controller calibration parameters for the head from YAML file named {0}'.format(filename))
         with open(filename, 'r') as fid:


### PR DESCRIPTION
Make it easy to run stretch_driver separately by loading the calibration yaml when the launch file doesn't set the parameter and by making it easy to comment out stretch_driver in the launch file. The reason to make this easy is because running stretch_driver as a node enables pdb.