### PR TITLE
Remove Unused Teleop Type Param in Mapping Launches 

### DIFF
--- a/stretch_rtabmap/launch/visual_mapping.launch.py
+++ b/stretch_rtabmap/launch/visual_mapping.launch.py
@@ -46,7 +46,6 @@ def generate_launch_description():
     return LaunchDescription([
         rviz_param,
         rviz_config,
-        teleop_type_param,
         stretch_driver_launch,
         d435i_launch,
         rtabmap_mapping_node,


### PR DESCRIPTION
This PR removes the unused teleop type param from `visual_mapping.launch.py`. It builds on PR https://github.com/hello-robot/stretch_ros2/pull/165 