### PR TITLE
Fix for flaky goal timeouts due to wrist pitch

### DIFF
--- a/stretch_core/stretch_core/command_groups.py
+++ b/stretch_core/stretch_core/command_groups.py
@@ -140,7 +140,7 @@ class WristYawCommandGroup(SimpleCommandGroup):
 
 class WristPitchCommandGroup(SimpleCommandGroup):
     def __init__(self, range_rad=None, node=None):
-        SimpleCommandGroup.__init__(self, 'joint_wrist_pitch', range_rad, node=node)
+        SimpleCommandGroup.__init__(self, 'joint_wrist_pitch', range_rad, acceptable_joint_error=0.03, node=node)
 
     def update_joint_range(self, joint_range, node=None):
         if joint_range is not None:

--- a/stretch_core/stretch_core/joint_trajectory_server.py
+++ b/stretch_core/stretch_core/joint_trajectory_server.py
@@ -224,13 +224,12 @@ class JointTrajectoryAction:
                     robot_status = self.node.robot.get_status()
                     named_errors = [c.update_execution(robot_status, contact_detected_callback=self.contact_detected_callback)
                                     for c in self.command_groups]
-                    # It's not clear how this could ever happen. The
-                    # groups in command_groups.py seem to return
-                    # (self.name, self.error) or None, rather than True.
+
+                    # One of the elements in named_errors will
+                    # be True when guarded contact is detected
                     if any(ret == True for ret in named_errors):
                         self.node.robot_mode_rwlock.release_read()
-                        # TODO: Check when this condtion is met
-                        return self.error_callback(goal_handle, 100, "--")
+                        return self.error_callback(goal_handle, 100, self._contact_detected_err_str)
 
                     self.feedback_callback(goal_handle, desired_point=point, named_errors=named_errors)
                     goals_reached = [c.goal_reached() for c in self.command_groups]
@@ -331,6 +330,7 @@ class JointTrajectoryAction:
 
 
     def contact_detected_callback(self, err_str):
+        self._contact_detected_err_str = err_str
         self.node.get_logger().warn(err_str)
     
     def invalid_joints_callback(self, err_str):


### PR DESCRIPTION
The threshold for an wrist pitch goal was set smaller than the joint can achieve given the noise profile of its encoders. This results in flaky behavior from the action server. 50% of the time, the encoder reports a position that falls within the threshold, and 50% of the time, the position is just outside the threshold. Ultimately, this cases the action server to timeout the goal after 10s. In this PR, we tune the acceptable thresholds to better match the joint's noise characteristics.

Additionally, this PR modifies the action server to report guarded contact errors in plaintext as part of the `error_string` attribute of the action result.

Merging this should fix: https://forum.hello-robot.com/t/indeterministic-followjointtrajectory-action-server-first-try-goal-aborted-second-try-succesful/1245