### PR TITLE
Set QT Plugin path from Streth Driver launch

### DIFF
--- a/stretch_core/launch/stretch_driver.launch.py
+++ b/stretch_core/launch/stretch_driver.launch.py
@@ -11,6 +11,9 @@ import importlib.resources
 import os
 import sys
 
+# this fixes rviz launch issue
+os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = '/usr/lib/x86_64-linux-gnu/qt5/plugins/platforms/libqxcb.so'
+
 
 def generate_launch_description():
     # Check is robot


### PR DESCRIPTION
Recently the rviz window seems to be failing due to QT plugin path issue that usually arises when `cv2` module in loaded which sets the qt plugin path away from the default linux qt binary.

Refer to the forum post [QT applications error out due to conflict with cv2 (Could not load the Qt platform plugin “xcb”)](https://forum.hello-robot.com/t/qt-applications-error-out-due-to-conflict-with-cv2-could-not-load-the-qt-platform-plugin-xcb/1047).