### PR TITLE
fix: MobileBaseCommandGroup crash when update_execution returns None

### DIFF
--- a/stretch_core/stretch_core/command_groups.py
+++ b/stretch_core/stretch_core/command_groups.py
@@ -646,7 +646,10 @@ class MobileBaseCommandGroup(SimpleCommandGroup):
 
         if self.active:
             if self.active_translate_mobile_base or self.active_rotate_mobile_base:
-                (_, mobile_base_error_m), (_, mobile_base_error_rad) = self.update_execution(robot_status)
+                ret = self.update_execution(robot_status)
+                if ret is None:
+                    return
+                (_, mobile_base_error_m), (_, mobile_base_error_rad) = ret
                 if mobile_base_error_m is not None:
                     robot.base.translate_by(mobile_base_error_m,
                                             v_m=self.goal_translate_mobile_base['velocity'],
@@ -708,6 +711,8 @@ class MobileBaseCommandGroup(SimpleCommandGroup):
         if self.active:
             if self.active_translate_mobile_base or self.active_rotate_mobile_base:
                 if self.active_translate_mobile_base:
+                    if self.error_translate_mobile_base_m is None:
+                        return True
                     reached = (abs(self.error_translate_mobile_base_m) < self.acceptable_mobile_base_error_m)
                     if not (abs(self.error_translate_mobile_base_m) < self.excellent_mobile_base_error_m):
                         # Use velocity to help decide when the low-level command has been finished


### PR DESCRIPTION
When a goal with translate_mobile_base = 0 is sent, set_goal() will not set the target position.

In this case, update_execution() returns None.

Before, init_execution() did not check this and tried to unpack the result, which caused a crash.

![Screenshot from 2025-06-13 11-53-45](https://github.com/user-attachments/assets/8aab8c82-da23-482a-9e93-c897d8f82375)

This commit adds a check to avoid unpacking when update_execution() returns None.

Now the node will not crash if a 0-translate goal is sent.

No change to the main behavior of mobile base movement.