### PR TITLE
include cython_min_cost_path .so in package data

### DIFF
--- a/stretch_funmap/setup.py
+++ b/stretch_funmap/setup.py
@@ -7,6 +7,10 @@ setup(
     name=package_name,
     version='0.0.0',
     packages=find_packages(),
+    include_package_data=True,  
+    package_data={              
+        package_name: ['cython_min_cost_path*.so'],
+    },
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),


### PR DESCRIPTION
Fixes a runtime import error in `stretch_funmap` by ensuring the compiled Cython extension `cython_min_cost_path*.so` is installed into the ROS 2 install-space site-packages.

The Cython module was being compiled in the source tree but not installed into `install/.../site-packages/stretch_funmap`, causing `ImportError` when running FUNMAP via `ros2 run` or `ros2 launch`:

```
[funmap-6] ImportError: cannot import name 'cython_min_cost_path' from 'stretch_funmap' (/home/hello-robot/ament_ws/install/stretch_funmap/lib/python3.10/site-packages/stretch_funmap/__init__.py)
```
This change includes the compiled `.so` as package data so it is correctly installed during `colcon build`.