### PR TITLE
Pin Mujoco to 3.2.6 in Docker build

### DIFF
--- a/stretch_simulation/Dockerfile
+++ b/stretch_simulation/Dockerfile
@@ -107,6 +107,12 @@ RUN /bin/bash -c "source ~/ament_ws/install/setup.bash && \
 # Fix PyOpenGL issue before setting up Mujoco
 RUN pip3 install PyOpenGL==3.1.4
 
+# Pin mujoco to what robocasa/stretch_mujoco require
+RUN printf "mujoco==3.2.6\n" > /tmp/pip-constraints.txt
+
+# Make pip honor the constraint during setup.sh (when it installs robosuite/robocasa deps)
+ENV PIP_CONSTRAINT=/tmp/pip-constraints.txt
+
 # Set up Mujoco
 # Note: The setup.sh script is interactive, so we'll need to provide "y" to download kitchen assets
 RUN /bin/bash -c "source ~/ament_ws/install/setup.bash && \


### PR DESCRIPTION
Fixes a Docker build failure where `robosuite` upgrades Mujoco to `3.4.0`, which breaks `stretch_mujoco` (both require `Mujoco 3.2.6`).

**Note:** This issue does not reproduce when following the `stretch_mujoco` [README](https://github.com/hello-robot/stretch_mujoco) install steps locally. The main difference appears to be that the README uses `uv`. I attempted installing `uv` in Docker and replicating the same `uv` commands, but Mujoco was still upgraded to `3.4.0` during the Docker build, leading to the same failure. With this pin in place, I was able to successfully build the Docker image.