### PR TITLE
Fix MuJoCo native install

### DIFF
--- a/stretch_simulation/README_SETUP.md
+++ b/stretch_simulation/README_SETUP.md
@@ -101,13 +101,11 @@ pip3 install --upgrade pip #This is important after a fresh install of Ubuntu, f
 
 source ~/ament_ws/install/setup.bash
 # This script is interactive, it will ask you if you want to install robocasa model files:
-sh ~/ament_ws/src/stretch_ros2/stretch_simulation/stretch_mujoco_driver/setup.sh
+bash ~/ament_ws/src/stretch_ros2/stretch_simulation/stretch_mujoco_driver/setup.sh
 
 pip install PyOpenGL==3.1.4 # Fixes AttributeError: module 'OpenGL.EGL' has no attribute 'EGLDeviceEXT'
 
 cd ~/ament_ws
-source ./install/setup.bash
-colcon build
 ros2 launch stretch_simulation stretch_mujoco_driver.launch.py mode:=navigation
 ```
 


### PR DESCRIPTION
## Description

Cleans up MuJoCo native install instructions:

* Use `bash` instead of `sh` (script uses source, which fails under `sh`)

* Remove redundant build and source (already handled in `stretch_simulation/stretch_mujoco_driver/setup.sh`)

## Test

Tested on: Ubuntu 22.04
Successfully launched:

ros2 launch stretch_simulation [stretch_mujoco_driver.launch.py](http://stretch_mujoco_driver.launch.py/) mode:=navigation
