### PR TITLE
Fix/docker compose mujoco cleanup

### DIFF
--- a/stretch_simulation/docker-compose.yml
+++ b/stretch_simulation/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  stretch-simulation:
+  stretch-simulation: 
     image: stretch-simulation:latest
     container_name: stretch-sim
     build:
@@ -12,18 +12,13 @@ services:
     stdin_open: true
     tty: true
     shm_size: '2gb'
-    environment:
+    environment: 
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
-      - MUJOCO_GL=egl
-      - HELLO_FLEET_PATH=/root/stretch_user
-      - HELLO_FLEET_ID=stretch
     volumes:
       # X11 socket for GUI
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ${HOME}/.Xauthority:/root/.Xauthority:rw
-      # Persistent data storage
-      - ${HOME}/stretch_data:/root/stretch_user:rw
       # Mount local source code for development
       - ./:/root/ament_ws/src/stretch_ros2/stretch_simulation:rw
     deploy:
@@ -32,5 +27,9 @@ services:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [gpu, compute, utility]
-
+              capabilities: [gpu]
+    command:
+      - bash
+      - -c
+      - |  
+        terminator -u --title="Task Container"

--- a/stretch_simulation/stretch_mujoco_driver/setup.sh
+++ b/stretch_simulation/stretch_mujoco_driver/setup.sh
@@ -1,11 +1,9 @@
-#!/bin/sh
-
-SCRIPT_DIR=$(dirname "$0")
+#!/usr/bin/env bash
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
-
 
 # ------------------------------------------------------------------
 # Force mujoco version required by robocasa/stretch_mujoco
@@ -14,9 +12,7 @@ CONSTRAINT_FILE=/tmp/stretch_mujoco_constraints.txt
 echo "mujoco==3.2.6" > $CONSTRAINT_FILE
 export PIP_CONSTRAINT=$CONSTRAINT_FILE
 
-mkdir -p dependencies
-
-cd dependencies
+cd ~/repos
 
 # Install stretch_mujoco and robocasa:
 git clone https://github.com/hello-robot/stretch_mujoco.git --depth 1


### PR DESCRIPTION
### Summary
This PR cleans up the docker-compose configuration and updates setup.sh to ensure bind-mounted volumes remain consistent and do not override or lose important data during development.

### Changes

#### Docker Compose
- Removed persistent volume mount (`~/stretch_data → /root/stretch_user`)
  - This was mounting a non-existent (empty) host directory over `/root/stretch_user`, which overrides and hides existing robot data inside the container

- Removed redundant environment variables
  - These are already handled in the Dockerfile

- Updated GPU configuration
  - Simplified to match current requirements

- Added `terminator` as container command
  - Improves interactive development workflow

#### setup.sh
- Updated `stretch_mujoco` installation location to `~/repos`
  - Previously installed inside the workspace
  - This caused it to be **overridden/hidden by the Docker bind mount**:
    ```
    ./:/root/ament_ws/src/stretch_ros2/stretch_simulation
    ```
  - Installing into `~/repos` ensures the package persists inside the container and is not affected by bind mounts

### How to Test

1. Rebuild the Docker image:
```
   cd /path/to/stretch_ros2/stretch_simulation
   docker build -t stretch-simulation:latest .
```

2. Run the container:

```
cd /path/to/stretch_ros2/stretch_simulation
xhost +local:docker
docker compose up
```