### PR TITLE
Fix docker simulation navigation demo commands

### DIFF
--- a/stretch_simulation/README_DOCKER.md
+++ b/stretch_simulation/README_DOCKER.md
@@ -233,12 +233,13 @@ docker compose up
 ros2 launch stretch_simulation stretch_mujoco_driver.launch.py \
     use_mujoco_viewer:=true \
     mode:=navigation \
+    use_rviz:=false \
     robocasa_layout:='G-shaped' \
     robocasa_style:=Modern_1
 
 # Terminal 2: Launch navigation
 ros2 launch stretch_nav2 navigation.launch.py \
-    map:=~/ament_ws/src/stretch_ros2/stretch_simulation/maps/gshaped_modern1_robocasa.yaml \
+    map:=/root/ament_ws/src/stretch_ros2/stretch_simulation/maps/gshaped_modern1_robocasa.yaml \
     use_sim_time:=true \
     use_rviz:=true \
     teleop_type:=none


### PR DESCRIPTION
This PR fixes issues in the `Navigation with Pre-mapped Scene` demo in the stretch simulation Docker setup.

Changes:
- Replaced `~` with `/root` in the map path since Nav2 map_server does not expand `~`, which caused the map to fail loading.
- Added `use_rviz:=false` to the Mujoco driver launch to prevent multiple RViz instances from launching.

These fixes ensure the navigation demo runs reliably inside the Docker environment.