### PR TITLE
Remap behavior_server cmd_vel to stretch/cmd_vel

### DIFF
--- a/stretch_nav2/launch/navigation_launch.py
+++ b/stretch_nav2/launch/navigation_launch.py
@@ -104,7 +104,7 @@ def generate_launch_description():
             name='behavior_server',
             output='screen',
             parameters=[configured_params],
-            remappings=remappings),
+            remappings=nav_remappings),
 
         Node(
             package='nav2_bt_navigator',


### PR DESCRIPTION
This PR remaps `/cmd_vel` to `/stretch/cmd_vel` for the `behavior_server` node to match the existing `controller_server` remapping.

Without this change, Nav2 behavior actions such as `/spin` publish velocity commands to `/cmd_vel`, while Stretch listens on `/stretch/cmd_vel`.

Tested with:

`ros2 action send_goal /spin nav2_msgs/action/Spin "{target_yaw: 1.57, time_allowance: {sec: 20, nanosec: 0}}"`