### PR TITLE
Fix GraspObjectNode initializaton order for ROS 2  humble

### DIFF
--- a/stretch_demos/stretch_demos/grasp_object.py
+++ b/stretch_demos/stretch_demos/grasp_object.py
@@ -25,7 +25,7 @@ class GraspObjectNode(hm.HelloNode):
         self.rate = 10.0
         self.joint_states = None
         self.joint_states_lock = threading.Lock()
-        self.move_base = nv.MoveBase(self)
+        self.move_base = None
         self.tool = None
         self.letter_height_m = 0.2
         self.wrist_position = None
@@ -199,6 +199,7 @@ class GraspObjectNode(hm.HelloNode):
     
     def main(self):
         hm.HelloNode.main(self, 'grasp_object', 'grasp_object', wait_for_first_pointcloud=False)
+        self.move_base = nv.MoveBase(self)
         self.logger = self.get_logger()
 
         self.callback_group = ReentrantCallbackGroup()


### PR DESCRIPTION
## Summary

Fix an initialization-order issue in `grasp_object` on ROS 2 Humble.

`MoveBase` was being constructed before the underlying ROS node was fully initialized. Since MoveBase declares ROS parameters during initialization, `ros2 run stretch_demos grasp_object` resulted in:

```
AttributeError: 'GraspObjectNode' object has no attribute '_parameter_overrides'
```

This change delays `MoveBase` initialization until after `HelloNode.main()` completes, ensuring the node is fully initialized before parameters are declared.

## Testing Notes

`grasp_object.py` depends on `stretch_funmap` Python packages through the virtual environment workflow.

To test this PR, first apply the companion [venv-wrapper PR](https://github.com/hello-robot/stretch_factory/pull/104) and re-wrap the `stretch_demos` executables:

```
REx_amend_venv_execs.py stretch_demos --venv-package stretch_funmap --force
```
Then verify that the node starts successfully:

```
ros2 run stretch_demos grasp_object
```

Before this fix, the command failed during startup with:

```
AttributeError: 'GraspObjectNode' object has no attribute '_parameter_overrides'
```

After this change, `grasp_object` should initialize successfully.
