### PR TITLE
Fix KeyError for SG3 Pro tool in manipulation planning with FUNMAP

### DIFF
--- a/stretch_funmap/stretch_funmap/manipulation_planning.py
+++ b/stretch_funmap/stretch_funmap/manipulation_planning.py
@@ -214,6 +214,7 @@ class ManipulationView():
             'tool_stretch_gripper': 'link_gripper',
             'tool_stretch_dex_wrist': 'link_wrist_yaw_bottom',#link_straight_gripper_aligned
             'eoa_wrist_dw3_tool_sg3': 'link_wrist_yaw_bottom',
+            'eoa_wrist_dw3_tool_sg3_pro': 'link_wrist_yaw_bottom',
         }
         self.tool = tool
 


### PR DESCRIPTION
This PR fixes a crash (`KeyError: 'eoa_wrist_dw3_tool_sg3_pro'`) that occurs when running `grasp_object.launch.py` with the new SG3 Pro tool.

It adds the missing `eoa_wrist_dw3_tool_sg3_pro` tool.